### PR TITLE
Placeholder for potential future HX|H264 and HX|HEVC - HX/HX2/HX3

### DIFF
--- a/src/obs-ndi-output.cpp
+++ b/src/obs-ndi-output.cpp
@@ -256,6 +256,13 @@ void ndi_output_destroy(void* data)
 	bfree(o);
 }
 
+// Define this in a more appropriate place and make this a settable option in the UI
+typedef enum HxMode {
+	None,
+	H264,
+	HEVC
+} HxMode;
+
 void ndi_output_rawvideo(void* data, struct video_data* frame)
 {
 	auto o = (struct ndi_output*)data;
@@ -287,7 +294,22 @@ void ndi_output_rawvideo(void* data, struct video_data* frame)
 		video_frame.line_stride_in_bytes = frame->linesize[0];
 	}
 
-	ndiLib->send_send_video_v2(o->ndi_sender, &video_frame);
+	// TODO:(pv) Option for HX H264/HEVC using NDI Advanced SDK example's send_send_video_scatter_async
+	//	Double-check that above format conversion code is compatible
+	HxMode hxMode = HxMode.H264;
+	switch(hxMode) {
+		case HxMode.None:
+			ndiLib->send_send_video_v2(o->ndi_sender, &video_frame);
+			break;
+		case HxMode.H264:
+			// Find way to reuse https://github.com/obsproject/obs-studio/blob/master/plugins/obs-x264/
+			// C:\Program Files\NDI\NDI 5 Advanced SDK\Examples\C++ (HX2)\NDIlib_Send_H264
+			break;
+		case HxMode.HEVC:
+			// Find way to reuse https://github.com/obsproject/obs-studio/blob/master/libobs/obs-hevc.c
+			// C:\Program Files\NDI\NDI 5 Advanced SDK\Examples\C++ (HX2)\NDIlib_Send_HEVC
+			break;
+	}
 }
 
 void ndi_output_rawaudio(void* data, struct audio_data* frame)


### PR DESCRIPTION
ABSOLUTELY DO NOT MERGE!

This is just a non-compiling prototype stub for now **to get the conversation going**.
This most likely will also require a non-trivial update to NDI SDK v5.
It looks like some work for this may have already been done on some other forks or the `rewrite` branch.
https://github.com/Palakis/obs-ndi/tree/rewrite

Also related to #720 

@Palakis I see that @tt2468 started a rewrite from scratch on 2021/07/18 and you last pushed on 2021/11/19.
I perused the code a little bit and saw that the meat of NDI output code is still empty:
https://github.com/Palakis/obs-ndi/blob/rewrite/src/obs-ndi-output.cpp

I see that you have also been mega busy with the excellent osb-websocket v5 rewrite.
Zero pressure on these questions, I am just curious:
* Is the rewrite still active?
* Is the plan for it to support HX H.264 and HEVC encoding?
If so then this PR could probably be abandoned.

If not, my initial goal for this branch from the `master` is to (cough) "simply":
1. update the NDI lib to v5
2. add NDI 5 HX H.264 and HEVC output options

Other forks may have tried, and I am wondering if this effort would be well-served to attempt on `master`, or if anyone [still] attempting this would be better off waiting for the rewrite.