### PR TITLE
Audio only patch

### DIFF
--- a/src/obs-ndi-source.cpp
+++ b/src/obs-ndi-source.cpp
@@ -539,9 +539,9 @@ void *ndi_source_thread(void *data)
 			     obs_source_ndi_receiver_name);
 
 			// Force a clean frame on receiver reset at all times.
-				obs_source_output_video(
-					obs_source,
-					config_most_recent.blank_frame);
+			obs_source_output_video(
+				obs_source,
+				config_most_recent.blank_frame);
 
 			if (ndi_frame_sync) {
 				ndiLib->framesync_destroy(ndi_frame_sync);

--- a/src/obs-ndi-source.cpp
+++ b/src/obs-ndi-source.cpp
@@ -497,9 +497,6 @@ void *ndi_source_thread(void *data)
 			case PROP_BW_AUDIO_ONLY:
 				recv_desc.bandwidth =
 					NDIlib_recv_bandwidth_audio_only;
-				obs_source_output_video(
-					obs_source,
-					config_most_recent.blank_frame);
 				break;
 			}
 			blog(LOG_INFO,
@@ -540,6 +537,11 @@ void *ndi_source_thread(void *data)
 			blog(LOG_INFO,
 			     "[obs-ndi] ndi_source_thread: '%s' Resetting NDI receiver...",
 			     obs_source_ndi_receiver_name);
+
+			// Force a clean frame on receiver reset at all times.
+				obs_source_output_video(
+					obs_source,
+					config_most_recent.blank_frame);
 
 			if (ndi_frame_sync) {
 				ndiLib->framesync_destroy(ndi_frame_sync);

--- a/src/obs-ndi-source.cpp
+++ b/src/obs-ndi-source.cpp
@@ -539,9 +539,8 @@ void *ndi_source_thread(void *data)
 			     obs_source_ndi_receiver_name);
 
 			// Force a clean frame on receiver reset at all times.
-			obs_source_output_video(
-				obs_source,
-				config_most_recent.blank_frame);
+			obs_source_output_video(obs_source,
+						config_most_recent.blank_frame);
 
 			if (ndi_frame_sync) {
 				ndiLib->framesync_destroy(ndi_frame_sync);


### PR DESCRIPTION
This should fix a bug that exist since.... 2017 (IIRC)

**BUT this is conflicting with some added new behavior when the source is enable but set to not keep the connection alive when not visible.**

Fix audio bug that audio-Only mode does not work when restarting OBS.

Main bug with workaround solution: https://github.com/obs-ndi/obs-ndi/issues/592

Should fix the issues :
https://github.com/obs-ndi/obs-ndi/issues/429
https://github.com/obs-ndi/obs-ndi/issues/578
https://github.com/obs-ndi/obs-ndi/issues/981
https://github.com/obs-ndi/obs-ndi/issues/906
https://github.com/obs-ndi/obs-ndi/issues/621
https://github.com/obs-ndi/obs-ndi/issues/467
https://github.com/obs-ndi/obs-ndi/issues/298

This was tested and confirmed fixing the bug on MAC OS on OBS 30.1.1.