### PR TITLE
settings: layout cleanup

### DIFF
--- a/src/forms/output-settings.ui
+++ b/src/forms/output-settings.ui
@@ -26,8 +26,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>565</width>
-    <height>560</height>
+    <width>400</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -39,14 +39,256 @@ with this program. If not, see <https://www.gnu.org/licenses/>
   <property name="windowTitle">
    <string>NDIPlugin.OutputSettings.DialogTitle</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
+  <layout class="QVBoxLayout">
+   <property name="leftMargin">
+    <number>12</number>
+   </property>
+   <property name="topMargin">
+    <number>12</number>
+   </property>
+   <property name="rightMargin">
+    <number>12</number>
+   </property>
+   <property name="bottomMargin">
+    <number>12</number>
+   </property>
+   <property name="spacing">
+    <number>6</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="mainOutputGroupBox">
+     <property name="styleSheet">
+      <string notr="true">QWidget { padding-top: 1em; }</string>
+     </property>
+     <property name="title">
+      <string>NDIPlugin.OutputSettings.GroupBox.Main</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridName">
+      <item row="0" column="0">
+       <widget class="QLabel" name="mainOutputNameLabel">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>NDIPlugin.OutputSettings.Main.Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mainOutputName">
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>mainOutputName</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mainOutputGroupsLabel">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>NDIPlugin.OutputSettings.Main.Groups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mainOutputGroups">
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>mainOutputGroups</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="previewOutputGroupBox">
+     <property name="styleSheet">
+      <string notr="true">QWidget { padding-top: 1em; }</string>
+     </property>
+     <property name="title">
+      <string>NDIPlugin.OutputSettings.GroupBox.Preview</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="previewOutputNameLabel">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>NDIPlugin.OutputSettings.Preview.Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="previewOutputName">
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>previewOutputName</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="previewOutputGroupsLabel">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>NDIPlugin.OutputSettings.Preview.Groups</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="previewOutputGroups">
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>previewOutputGroups</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="tallyGroupBox">
+     <property name="styleSheet">
+      <string notr="true">QWidget { padding-top: 1em; }</string>
+     </property>
+     <property name="title">
+      <string>NDIPlugin.OutputSettings.GroupBox.Tally</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="tallyProgramNameLabel">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>NDIPlugin.OutputSettings.GroupBox.Tally.Program</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="tallyProgramCheckBox">
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>NDIPlugin.OutputSettings.GroupBox.Tally.Enable</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="tallyPreviewNameLabel">
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>NDIPlugin.OutputSettings.GroupBox.Tally.Preview</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="tallyPreviewCheckBox">
+        <property name="styleSheet">
+         <string notr="true">QWidget { padding: 0; }</string>
+        </property>
+        <property name="text">
+         <string>NDIPlugin.OutputSettings.GroupBox.Tally.Enable</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayoutObsNdi">
      <item>
       <widget class="QLabel" name="labelObsNdiVersion">
        <property name="font">
         <font>
-         <pointsize>8</pointsize>
+         <bold>true</bold>
         </font>
        </property>
        <property name="text">
@@ -63,10 +305,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
      </item>
     </layout>
    </item>
-   <item row="4" column="0">
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayoutAutoCheckForUpdates">
      <item>
-      <spacer name="horizontalSpacerAutoCheckForUpdatesLeft">
+      <spacer>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -87,275 +329,20 @@ with this program. If not, see <https://www.gnu.org/licenses/>
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayoutDiscord">
-     <item>
-      <spacer name="horizontalSpacerDiscordLeft">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelDiscord">
-       <property name="text">
-        <string>Discord (English):</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelDiscordUrl">
-       <property name="text">
-        <string>Discord URL</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacerDiscordRight">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="6" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QLabel" name="labelDonate">
-       <property name="text">
-        <string>NDIPlugin.Donate</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelDonateUrl">
-       <property name="text">
-        <string>Donate URL</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="previewOutputGroupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>NDIPlugin.OutputSettings.GroupBox.Preview</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignJustify|Qt::AlignVCenter</set>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout_5">
-      <item row="0" column="0" colspan="2">
-       <layout class="QFormLayout" name="formLayout_4">
-        <item row="0" column="0">
-         <widget class="QLabel" name="previewOutputNameLabel">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>NDIPlugin.OutputSettings.Preview.Name</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="previewOutputName"/>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <layout class="QFormLayout" name="formLayout_9">
-        <item row="0" column="0">
-         <widget class="QLabel" name="previewOutputGroupsLabel">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>NDIPlugin.OutputSettings.Preview.Groups</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="previewOutputGroups"/>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="tallyGroupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>NDIPlugin.OutputSettings.GroupBox.Tally</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignJustify|Qt::AlignVCenter</set>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout_6">
-      <item row="0" column="0" colspan="2">
-       <layout class="QFormLayout" name="formLayout_7">
-        <item row="0" column="0">
-         <widget class="QLabel" name="tallyProgramNameLabel">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>NDIPlugin.OutputSettings.GroupBox.Tally.Program</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QCheckBox" name="tallyProgramCheckBox">
-          <property name="text">
-           <string>NDIPlugin.OutputSettings.GroupBox.Tally.Enable</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <layout class="QFormLayout" name="formLayout_8">
-        <item row="0" column="0">
-         <widget class="QLabel" name="tallyPreviewNameLabel">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>NDIPlugin.OutputSettings.GroupBox.Tally.Preview</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QCheckBox" name="tallyPreviewCheckBox">
-          <property name="text">
-           <string>NDIPlugin.OutputSettings.GroupBox.Tally.Enable</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
+   <item>
+    <widget class="Line" name="line3">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayoutNdi">
      <item>
       <widget class="QLabel" name="labelNdiVersion">
        <property name="font">
         <font>
-         <pointsize>8</pointsize>
+         <bold>true</bold>
         </font>
        </property>
        <property name="text">
@@ -386,65 +373,102 @@ with this program. If not, see <https://www.gnu.org/licenses/>
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="mainOutputGroupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item>
+    <widget class="Line" name="line2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="title">
-      <string>NDIPlugin.OutputSettings.GroupBox.Main</string>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="labelDonate">
+       <property name="text">
+        <string>NDIPlugin.Donate</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelDonateUrl">
+       <property name="text">
+        <string>Donate URL</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line1">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="checkable">
-      <bool>true</bool>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutDiscord">
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelDiscord">
+       <property name="text">
+        <string>Discord (English):</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelDiscordUrl">
+       <property name="text">
+        <string>Discord URL</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="checked">
-      <bool>false</bool>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
-     <layout class="QFormLayout" name="formLayout_3">
-      <item row="0" column="0" colspan="2">
-       <layout class="QFormLayout" name="formLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="mainOutputNameLabel">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>NDIPlugin.OutputSettings.Main.Name</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="mainOutputName"/>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <layout class="QFormLayout" name="formLayout_10">
-        <item row="0" column="0">
-         <widget class="QLabel" name="mainOutputGroupsLabel">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>NDIPlugin.OutputSettings.Main.Groups</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="mainOutputGroups"/>
-        </item>
-       </layout>
-      </item>
-     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
The `output-settings.ui` file was a bit of a mess.
The outer layout was a `QGridLayout` with only 1 column.
The layout row numbers jumped around all over the place.
I changed this to a `QVBoxLayout`, which required all of the rows to be in order.

I also improved the padding and and spacers.

I added hr lines in a few places.

Before:
![image](https://github.com/user-attachments/assets/4876d8b3-59ae-4afd-ae58-25e5edd97bf2)

After:
![image](https://github.com/user-attachments/assets/f780de79-c21b-4e9d-ab51-2345084c2f84)
