### PR TITLE
config: add `--obs-ndi-update-local` parameter

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -41,6 +41,7 @@ Config *Config::_instance = nullptr;
 bool _LogVerbose = false;
 bool _LogDebug = false;
 bool _UpdateForce = false;
+UpdateHostEnum _UpdateHost = UpdateHostEnum::Production;
 
 bool Config::LogVerbose()
 {
@@ -57,6 +58,43 @@ bool Config::UpdateForce()
 	return _UpdateForce;
 }
 
+UpdateHostEnum Config::UpdateHost()
+{
+	return _UpdateHost;
+}
+
+void ProcessCommandLine()
+{
+	auto arguments = QCoreApplication::arguments();
+
+	if (arguments.contains("--obs-ndi-verbose",
+			       Qt::CaseSensitivity::CaseInsensitive)) {
+		blog(LOG_INFO,
+		     "[obs-ndi] Config: obs-ndi verbose logging enabled");
+		_LogVerbose = true;
+	}
+	if (arguments.contains("--obs-ndi-debug",
+			       Qt::CaseSensitivity::CaseInsensitive)) {
+		blog(LOG_INFO,
+		     "[obs-ndi] Config: obs-ndi debug logging enabled");
+		_LogDebug = true;
+	}
+
+	if (arguments.contains("--obs-ndi-update-force",
+			       Qt::CaseSensitivity::CaseInsensitive)) {
+		blog(LOG_INFO,
+		     "[obs-ndi] Config: obs-ndi update force enabled");
+		_UpdateForce = true;
+	}
+
+	if (arguments.contains("--obs-ndi-update-local",
+			       Qt::CaseSensitivity::CaseInsensitive)) {
+		blog(LOG_INFO,
+		     "[obs-ndi] Config: obs-ndi update host set to Local");
+		_UpdateHost = UpdateHostEnum::LocalEmulator;
+	}
+}
+
 Config::Config()
 	: OutputEnabled(false),
 	  OutputName("OBS"),
@@ -67,22 +105,7 @@ Config::Config()
 	  TallyProgramEnabled(true),
 	  TallyPreviewEnabled(true)
 {
-	auto arguments = QCoreApplication::arguments();
-	if (arguments.contains("--obs-ndi-verbose")) {
-		blog(LOG_INFO,
-		     "[obs-ndi] Config: obs-ndi verbose logging enabled");
-		_LogVerbose = true;
-	}
-	if (arguments.contains("--obs-ndi-debug")) {
-		blog(LOG_INFO,
-		     "[obs-ndi] Config: obs-ndi debug logging enabled");
-		_LogDebug = true;
-	}
-	if (arguments.contains("--obs-ndi-update-force")) {
-		blog(LOG_INFO,
-		     "[obs-ndi] Config: obs-ndi update force enabled");
-		_UpdateForce = true;
-	}
+	ProcessCommandLine();
 
 	auto obs_config = GetGlobalConfig();
 	if (obs_config) {

--- a/src/Config.h
+++ b/src/Config.h
@@ -21,6 +21,31 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QVersionNumber>
 #include <obs-module.h>
 
+enum UpdateHostEnum {
+	Production,
+	LocalEmulator,
+};
+
+/**
+ * Loads and Saves configuration settings from/to:
+ * Linux: TBD...
+ * MacOS: ~/Library/Application Support/obs-studio/global.ini
+ * Windows: %APPDATA%\obs-studio\global.ini
+ * 
+ * ```
+ * [NDIPlugin]
+ * MainOutputEnabled=true
+ * MainOutputName=OBS
+ * PreviewOutputEnabled=false
+ * PreviewOutputName=OBS Preview
+ * TallyProgramEnabled=false
+ * TallyPreviewEnabled=false
+ * CheckForUpdates=true
+ * AutoCheckForUpdates=true
+ * MainOutputGroups=
+ * PreviewOutputGroups=
+ * ```
+ */
 class Config {
 public:
 	static Config *Current();
@@ -29,6 +54,7 @@ public:
 	static bool LogVerbose();
 	static bool LogDebug();
 	static bool UpdateForce();
+	static UpdateHostEnum UpdateHost();
 
 	void Load();
 	void Save();

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -82,10 +82,11 @@ OutputSettings *output_settings = nullptr;
 QString rehostUrl(const char *url)
 {
 	auto result = QString::fromUtf8(url);
-#ifdef USE_LOCALHOST
-	result.replace("https://distroav.org",
-		       QString("http://%1:5002").arg(PLUGIN_WEB_HOST));
-#endif
+	if (Config::UpdateHost() == UpdateHostEnum::LocalEmulator) {
+		result.replace("https://distroav.org",
+			       QString("http://%1:5002")
+				       .arg(PLUGIN_WEB_HOST_LOCAL_EMULATOR));
+	}
 	return result;
 }
 
@@ -123,7 +124,7 @@ void showUnloadingMessageBoxDelayed(const QString &title,
 					   newMessage, QMessageBox::Ok,
 					   nullptr);
 #if defined(__APPLE__)
-		// https://stackoverflow.com/a/22187538/25683720
+		// Make title bar show text: https://stackoverflow.com/a/22187538/25683720
 		dlg->QDialog::setWindowTitle(newTitle);
 #endif
 		dlg->setAttribute(Qt::WA_DeleteOnClose, true);

--- a/src/plugin-main.h
+++ b/src/plugin-main.h
@@ -51,15 +51,8 @@ The following accomplishes two goals:
 	There is always the possibility that the user may **see** a "out of date" url, but when they
 	click on it the distroav.org server will redirect them to the latest url.
 */
-#define PLUGIN_WEB_HOST_LOCALHOST "127.0.0.1"
+#define PLUGIN_WEB_HOST_LOCAL_EMULATOR "127.0.0.1"
 #define PLUGIN_WEB_HOST_PRODUCTION "distroav.org"
-
-//#define USE_LOCALHOST
-#ifdef USE_LOCALHOST
-#define PLUGIN_WEB_HOST PLUGIN_WEB_HOST_LOCALHOST
-#else
-#define PLUGIN_WEB_HOST PLUGIN_WEB_HOST_PRODUCTION
-#endif
 
 QString rehostUrl(const char *url);
 QString makeLink(const char *url, const char *text = nullptr);


### PR DESCRIPTION
This is for development purposes to point to a local firebase emulator update host.
Avoids the need to recompile every time I want to switch between local and production update hosts.