### PR TITLE
6.0.0 logging & command-line argument tweaks

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -21,10 +21,7 @@
 #include <QString>
 #include <QVersionNumber>
 
-enum UpdateHostEnum {
-	Production,
-	LocalEmulator,
-};
+#define DEFAULT_UPDATE_LOCAL_PORT 5002
 
 /**
  * Loads and Saves configuration settings from/to:
@@ -32,6 +29,7 @@ enum UpdateHostEnum {
  * MacOS: ~/Library/Application Support/obs-studio/global.ini
  * Windows: %APPDATA%\obs-studio\global.ini
  * 
+ * Example:
  * ```
  * [NDIPlugin]
  * MainOutputEnabled=true
@@ -51,13 +49,25 @@ public:
 	static Config *Current(bool load = true);
 	static void Destroy();
 
-	static bool LogVerbose();
-	static bool LogDebug();
-	static bool UpdateForce();
-	static UpdateHostEnum UpdateHost();
-	static int UpdateLocalPort();
-	static bool UpdateLastCheckIgnore();
-	static int DetectObsNdiForce();
+	/**
+	 * -1 = `--DistroAV-update-force=-1` : force update less than current version
+	 * 0 = update normally
+	 * 1= `--DistroAV-update-force=1` : force update greater than current version
+	 */
+	static int UpdateForce;
+	/**
+	 * Default: DEFAULT_UPDATE_LOCAL_PORT
+	 * `--DistroAV-update-local`
+	 * `--DistroAV-update-local=5000`
+	 */
+	static int UpdateLocalPort;
+	static bool UpdateLastCheckIgnore;
+	/**
+	 * -1 = `--DistroAV-detect-obsndi-force=off` : force OBS-NDI not detected
+	 *  0 = detect normally
+	 *  1 = `--DistroAV-detect-obsndi-force=on` : force OBS-NDI detected
+	 */
+	static int DetectObsNdiForce;
 
 	bool OutputEnabled;
 	QString OutputName;
@@ -81,6 +91,7 @@ public:
 
 private:
 	void Load();
+	void SetDefaultsToGlobalStore();
 	Config();
 	static Config *_instance;
 };

--- a/src/forms/output-settings.cpp
+++ b/src/forms/output-settings.cpp
@@ -72,7 +72,7 @@ OutputSettings::OutputSettings(QWidget *parent)
 
 			if (!pluginUpdateInfo.errorData.isEmpty()) {
 				QString errorData = pluginUpdateInfo.errorData;
-				if (!Config::LogDebug()) {
+				if (LOG_LEVEL >= LOG_DEBUG) {
 					QJsonParseError parseError;
 					QJsonDocument jsonDoc =
 						QJsonDocument::fromJson(
@@ -109,7 +109,7 @@ The update server says you are not using an official release.<br>
 <br>
 Update checks are only supported for official releases.
 )";
-					if (Config::LogDebug()) {
+					if (LOG_LEVEL >= LOG_DEBUG) {
 						errorText += R"(<br>
 <br>
 If you are running a local build, don't forget to add your build info to the update server.
@@ -126,7 +126,7 @@ If you are running a local build, don't forget to add your build info to the upd
 
 			if (pluginUpdateInfo.versionLatest <=
 				    pluginUpdateInfo.versionCurrent &&
-			    !Config::UpdateForce()) {
+			    Config::UpdateForce < 1) {
 				QMessageBox::information(
 					this,
 					QTStr("NDIPlugin.Update.NoUpdateAvailable")

--- a/src/main-output.cpp
+++ b/src/main-output.cpp
@@ -24,12 +24,12 @@ static bool main_output_running = false;
 
 void main_output_start(const char *output_name, const char *output_groups)
 {
-	blog(LOG_INFO, "[DistroAV] +main_output_start(`%s`, `%s`)", output_name,
-	     output_groups);
+	obs_log(LOG_INFO, "+main_output_start(`%s`, `%s`)", output_name,
+		output_groups);
 	if (!main_output_running) {
-		blog(LOG_INFO,
-		     "[DistroAV] main_output_start: starting NDI main output with name '%s'",
-		     output_name);
+		obs_log(LOG_INFO,
+			"main_output_start: starting NDI main output with name '%s'",
+			output_name);
 
 		obs_data_t *settings = obs_data_create();
 		obs_data_set_string(settings, "ndi_name", output_name);
@@ -39,32 +39,31 @@ void main_output_start(const char *output_name, const char *output_groups)
 		obs_data_release(settings);
 		if (main_out) {
 			auto result = obs_output_start(main_out);
-			blog(LOG_INFO,
-			     "[DistroAV] main_output_start: obs_output_start result=%d",
-			     result);
+			obs_log(LOG_INFO,
+				"main_output_start: obs_output_start result=%d",
+				result);
 
 			main_output_running = true;
 
-			blog(LOG_INFO,
-			     "[DistroAV] main_output_start: started NDI main output");
+			obs_log(LOG_INFO,
+				"main_output_start: started NDI main output");
 		} else {
-			blog(LOG_ERROR,
-			     "[DistroAV] main_output_start: failed to create NDI main output");
+			obs_log(LOG_ERROR,
+				"main_output_start: failed to create NDI main output");
 		}
 	} else {
-		blog(LOG_INFO,
-		     "[DistroAV] main_output_start: NDI main output already running");
+		obs_log(LOG_INFO,
+			"main_output_start: NDI main output already running");
 	}
-	blog(LOG_INFO, "[DistroAV] -main_output_start(`%s`, `%s`)", output_name,
-	     output_groups);
+	obs_log(LOG_INFO, "-main_output_start(`%s`, `%s`)", output_name,
+		output_groups);
 }
 
 void main_output_stop()
 {
-	blog(LOG_INFO, "[DistroAV] +main_output_stop()");
+	obs_log(LOG_INFO, "+main_output_stop()");
 	if (main_output_running) {
-		blog(LOG_INFO,
-		     "[DistroAV] main_output_stop: stopping NDI main output");
+		obs_log(LOG_INFO, "main_output_stop: stopping NDI main output");
 
 		obs_output_stop(main_out);
 		obs_output_release(main_out);
@@ -72,13 +71,12 @@ void main_output_stop()
 
 		main_output_running = false;
 
-		blog(LOG_INFO,
-		     "[DistroAV] main_output_stop: stopped NDI main output");
+		obs_log(LOG_INFO, "main_output_stop: stopped NDI main output");
 	} else {
-		blog(LOG_INFO,
-		     "[DistroAV] main_output_stop: NDI main output not running");
+		obs_log(LOG_INFO,
+			"main_output_stop: NDI main output not running");
 	}
-	blog(LOG_INFO, "[DistroAV] -main_output_stop()");
+	obs_log(LOG_INFO, "-main_output_stop()");
 }
 
 bool main_output_is_running()

--- a/src/ndi-filter.cpp
+++ b/src/ndi-filter.cpp
@@ -68,7 +68,7 @@ void ndi_filter_update(void *data, obs_data_t *settings);
 
 obs_properties_t *ndi_filter_getproperties(void *)
 {
-	blog(LOG_INFO, "[DistroAV] +ndi_filter_getproperties(...)");
+	obs_log(LOG_INFO, "+ndi_filter_getproperties(...)");
 	obs_properties_t *props = obs_properties_create();
 	obs_properties_set_flags(props, OBS_PROPERTIES_DEFER_UPDATE);
 
@@ -104,18 +104,18 @@ obs_properties_t *ndi_filter_getproperties(void *)
 	obs_properties_add_group(props, "ndi", "NDI®", OBS_GROUP_NORMAL,
 				 group_ndi);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_filter_getproperties(...)");
+	obs_log(LOG_INFO, "-ndi_filter_getproperties(...)");
 	return props;
 }
 
 void ndi_filter_getdefaults(obs_data_t *defaults)
 {
-	blog(LOG_INFO, "[DistroAV] +ndi_filter_getdefaults(...)");
+	obs_log(LOG_INFO, "+ndi_filter_getdefaults(...)");
 	obs_data_set_default_string(
 		defaults, FLT_PROP_NAME,
 		obs_module_text("NDIPlugin.FilterProps.NDIName.Default"));
 	obs_data_set_default_string(defaults, FLT_PROP_GROUPS, "");
-	blog(LOG_INFO, "[DistroAV] -ndi_filter_getdefaults(...)");
+	obs_log(LOG_INFO, "-ndi_filter_getdefaults(...)");
 }
 
 void ndi_filter_raw_video(void *data, video_data *frame)
@@ -230,7 +230,7 @@ void ndi_filter_update(void *data, obs_data_t *settings)
 	auto f = (ndi_filter_t *)data;
 	auto obs_source = f->obs_source;
 	auto name = obs_source_get_name(obs_source);
-	blog(LOG_INFO, "[DistroAV] +ndi_filter_update(name=`%s`)", name);
+	obs_log(LOG_INFO, "+ndi_filter_update(name=`%s`)", name);
 
 	obs_remove_main_render_callback(ndi_filter_offscreen_render, f);
 
@@ -256,15 +256,15 @@ void ndi_filter_update(void *data, obs_data_t *settings)
 		obs_add_main_render_callback(ndi_filter_offscreen_render, f);
 	}
 
-	blog(LOG_INFO, "[DistroAV] -ndi_filter_update(name=`%s`)", name);
+	obs_log(LOG_INFO, "-ndi_filter_update(name=`%s`)", name);
 }
 
 void *ndi_filter_create(obs_data_t *settings, obs_source_t *obs_source)
 {
 	auto name = obs_data_get_string(settings, FLT_PROP_NAME);
 	auto groups = obs_data_get_string(settings, FLT_PROP_GROUPS);
-	blog(LOG_INFO, "[DistroAV] +ndi_filter_create(name=`%s`, groups=`%s`)",
-	     name, groups);
+	obs_log(LOG_INFO, "+ndi_filter_create(name=`%s`, groups=`%s`)", name,
+		groups);
 
 	auto f = (ndi_filter_t *)bzalloc(sizeof(ndi_filter_t));
 	f->obs_source = obs_source;
@@ -276,7 +276,7 @@ void *ndi_filter_create(obs_data_t *settings, obs_source_t *obs_source)
 
 	ndi_filter_update(f, settings);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_filter_create(...)");
+	obs_log(LOG_INFO, "-ndi_filter_create(...)");
 
 	return f;
 }
@@ -286,9 +286,9 @@ void *ndi_filter_create_audioonly(obs_data_t *settings,
 {
 	auto name = obs_data_get_string(settings, FLT_PROP_NAME);
 	auto groups = obs_data_get_string(settings, FLT_PROP_GROUPS);
-	blog(LOG_INFO,
-	     "[DistroAV] +ndi_filter_create_audioonly(name=`%s`, groups=`%s`)",
-	     name, groups);
+	obs_log(LOG_INFO,
+		"+ndi_filter_create_audioonly(name=`%s`, groups=`%s`)", name,
+		groups);
 
 	auto f = (ndi_filter_t *)bzalloc(sizeof(ndi_filter_t));
 	f->is_audioonly = true;
@@ -298,7 +298,7 @@ void *ndi_filter_create_audioonly(obs_data_t *settings,
 
 	ndi_filter_update(f, settings);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_filter_create_audioonly(...)");
+	obs_log(LOG_INFO, "-ndi_filter_create_audioonly(...)");
 
 	return f;
 }
@@ -307,7 +307,7 @@ void ndi_filter_destroy(void *data)
 {
 	auto f = (ndi_filter_t *)data;
 	auto name = obs_source_get_name(f->obs_source);
-	blog(LOG_INFO, "[DistroAV] +ndi_filter_destroy('%s'...)", name);
+	obs_log(LOG_INFO, "+ndi_filter_destroy('%s'...)", name);
 
 	obs_remove_main_render_callback(ndi_filter_offscreen_render, f);
 	video_output_close(f->video_output);
@@ -323,24 +323,22 @@ void ndi_filter_destroy(void *data)
 	gs_texrender_destroy(f->texrender);
 
 	if (f->audio_conv_buffer) {
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_filter_destroy: freeing %zu bytes",
-		     f->audio_conv_buffer_size);
+		obs_log(LOG_INFO, "ndi_filter_destroy: freeing %zu bytes",
+			f->audio_conv_buffer_size);
 		bfree(f->audio_conv_buffer);
 		f->audio_conv_buffer = nullptr;
 	}
 
 	bfree(f);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_filter_destroy('%s'...)", name);
+	obs_log(LOG_INFO, "-ndi_filter_destroy('%s'...)", name);
 }
 
 void ndi_filter_destroy_audioonly(void *data)
 {
 	auto f = (ndi_filter_t *)data;
 	auto name = obs_source_get_name(f->obs_source);
-	blog(LOG_INFO, "[DistroAV] +ndi_filter_destroy_audioonly('%s'...)",
-	     name);
+	obs_log(LOG_INFO, "+ndi_filter_destroy_audioonly('%s'...)", name);
 
 	pthread_mutex_lock(&f->ndi_sender_audio_mutex);
 	ndiLib->send_destroy(f->ndi_sender);
@@ -353,8 +351,7 @@ void ndi_filter_destroy_audioonly(void *data)
 
 	bfree(f);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_filter_destroy_audioonly('%s'...)",
-	     name);
+	obs_log(LOG_INFO, "-ndi_filter_destroy_audioonly('%s'...)", name);
 }
 
 void ndi_filter_tick(void *data, float)
@@ -388,18 +385,17 @@ obs_audio_data *ndi_filter_asyncaudio(void *data, obs_audio_data *audio_data)
 		audio_frame.no_channels * audio_frame.channel_stride_in_bytes;
 
 	if (data_size > f->audio_conv_buffer_size) {
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_filter_asyncaudio: growing audio_conv_buffer from %zu to %zu bytes",
-		     f->audio_conv_buffer_size, data_size);
+		obs_log(LOG_INFO,
+			"ndi_filter_asyncaudio: growing audio_conv_buffer from %zu to %zu bytes",
+			f->audio_conv_buffer_size, data_size);
 		if (f->audio_conv_buffer) {
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_filter_asyncaudio: freeing %zu bytes",
-			     f->audio_conv_buffer_size);
+			obs_log(LOG_INFO,
+				"ndi_filter_asyncaudio: freeing %zu bytes",
+				f->audio_conv_buffer_size);
 			bfree(f->audio_conv_buffer);
 		}
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_filter_asyncaudio: allocating %zu bytes",
-		     data_size);
+		obs_log(LOG_INFO, "ndi_filter_asyncaudio: allocating %zu bytes",
+			data_size);
 		f->audio_conv_buffer = (uint8_t *)bmalloc(data_size);
 		f->audio_conv_buffer_size = data_size;
 	}

--- a/src/ndi-output.cpp
+++ b/src/ndi-output.cpp
@@ -88,7 +88,7 @@ const char *ndi_output_getname(void *)
 
 obs_properties_t *ndi_output_getproperties(void *)
 {
-	blog(LOG_INFO, "[DistroAV] +ndi_output_getproperties()");
+	obs_log(LOG_INFO, "+ndi_output_getproperties()");
 
 	obs_properties_t *props = obs_properties_create();
 	obs_properties_set_flags(props, OBS_PROPERTIES_DEFER_UPDATE);
@@ -102,21 +102,21 @@ obs_properties_t *ndi_output_getproperties(void *)
 		obs_module_text("NDIPlugin.OutputProps.NDIGroups"),
 		OBS_TEXT_DEFAULT);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_output_getproperties()");
+	obs_log(LOG_INFO, "-ndi_output_getproperties()");
 
 	return props;
 }
 
 void ndi_output_getdefaults(obs_data_t *settings)
 {
-	blog(LOG_INFO, "[DistroAV] +ndi_output_getdefaults()");
+	obs_log(LOG_INFO, "+ndi_output_getdefaults()");
 	obs_data_set_default_string(settings, "ndi_name",
 				    "DistroAV output (changeme)");
 	obs_data_set_default_string(settings, "ndi_groups",
 				    "DistroAV output (changeme)");
 	obs_data_set_default_bool(settings, "uses_video", true);
 	obs_data_set_default_bool(settings, "uses_audio", true);
-	blog(LOG_INFO, "[DistroAV] -ndi_output_getdefaults()");
+	obs_log(LOG_INFO, "-ndi_output_getdefaults()");
 }
 
 void ndi_output_update(void *data, obs_data_t *settings);
@@ -125,15 +125,14 @@ void *ndi_output_create(obs_data_t *settings, obs_output_t *output)
 {
 	auto name = obs_data_get_string(settings, "ndi_name");
 	auto groups = obs_data_get_string(settings, "ndi_groups");
-	blog(LOG_INFO,
-	     "[DistroAV] +ndi_output_create(name='%s', groups='%s', ...)", name,
-	     groups);
+	obs_log(LOG_INFO, "+ndi_output_create(name='%s', groups='%s', ...)",
+		name, groups);
 	auto o = (ndi_output_t *)bzalloc(sizeof(ndi_output_t));
 	o->output = output;
 	ndi_output_update(o, settings);
-	blog(LOG_INFO,
-	     "[DistroAV] -ndi_output_create(name='%s', groups='%s', ...)", name,
-	     groups);
+
+	obs_log(LOG_INFO, "-ndi_output_create(name='%s', groups='%s', ...)",
+		name, groups);
 	return o;
 }
 
@@ -142,13 +141,12 @@ bool ndi_output_start(void *data)
 	auto o = (ndi_output_t *)data;
 	auto name = o->ndi_name;
 	auto groups = o->ndi_groups;
-	blog(LOG_INFO,
-	     "[DistroAV] +ndi_output_start(name='%s', groups='%s', ...)", name,
-	     groups);
+	obs_log(LOG_INFO, "+ndi_output_start(name='%s', groups='%s', ...)",
+		name, groups);
 	if (o->started) {
-		blog(LOG_INFO,
-		     "[DistroAV] -ndi_output_start(name='%s', groups='%s', ...)",
-		     name, groups);
+		obs_log(LOG_INFO,
+			"-ndi_output_start(name='%s', groups='%s', ...)", name,
+			groups);
 		return false;
 	}
 
@@ -157,11 +155,10 @@ bool ndi_output_start(void *data)
 	audio_t *audio = obs_output_audio(o->output);
 
 	if (!video && !audio) {
-		blog(LOG_ERROR, "[DistroAV] '%s': no video and audio available",
-		     name);
-		blog(LOG_INFO,
-		     "[DistroAV] -ndi_output_start(name='%s', groups='%s', ...)",
-		     name, groups);
+		obs_log(LOG_ERROR, "'%s': no video and audio available", name);
+		obs_log(LOG_INFO,
+			"-ndi_output_start(name='%s', groups='%s', ...)", name,
+			groups);
 		return false;
 	}
 
@@ -201,12 +198,11 @@ bool ndi_output_start(void *data)
 			break;
 
 		default:
-			blog(LOG_WARNING,
-			     "[DistroAV] warning: unsupported pixel format %d",
-			     format);
-			blog(LOG_INFO,
-			     "[DistroAV] -ndi_output_start(name='%s', groups='%s', ...)",
-			     name, groups);
+			obs_log(LOG_WARNING,
+				"warning: unsupported pixel format %d", format);
+			obs_log(LOG_INFO,
+				"-ndi_output_start(name='%s', groups='%s', ...)",
+				name, groups);
 			return false;
 		}
 
@@ -235,21 +231,17 @@ bool ndi_output_start(void *data)
 	if (o->ndi_sender) {
 		o->started = obs_output_begin_data_capture(o->output, flags);
 		if (o->started) {
-			blog(LOG_INFO, "[DistroAV] '%s': ndi output started",
-			     name);
+			obs_log(LOG_INFO, "'%s': ndi output started", name);
 		} else {
-			blog(LOG_ERROR,
-			     "[DistroAV] '%s': data capture start failed",
-			     name);
+			obs_log(LOG_ERROR, "'%s': data capture start failed",
+				name);
 		}
 	} else {
-		blog(LOG_ERROR, "[DistroAV] '%s': ndi sender init failed",
-		     name);
+		obs_log(LOG_ERROR, "'%s': ndi sender init failed", name);
 	}
 
-	blog(LOG_INFO,
-	     "[DistroAV] -ndi_output_start(name='%s', groups='%s'...)", name,
-	     groups);
+	obs_log(LOG_INFO, "-ndi_output_start(name='%s', groups='%s'...)", name,
+		groups);
 
 	return o->started;
 }
@@ -259,9 +251,8 @@ void ndi_output_update(void *data, obs_data_t *settings)
 	auto o = (ndi_output_t *)data;
 	auto name = obs_data_get_string(settings, "ndi_name");
 	auto groups = obs_data_get_string(settings, "ndi_groups");
-	blog(LOG_INFO,
-	     "[DistroAV] ndi_output_update(name='%s', groups='%s', ...)", name,
-	     groups);
+	obs_log(LOG_INFO, "ndi_output_update(name='%s', groups='%s', ...)",
+		name, groups);
 	o->ndi_name = name;
 	o->ndi_groups = groups;
 	o->uses_video = obs_data_get_bool(settings, "uses_video");
@@ -273,13 +264,12 @@ void ndi_output_stop(void *data, uint64_t)
 	auto o = (ndi_output_t *)data;
 	auto name = o->ndi_name;
 	auto groups = o->ndi_groups;
-	blog(LOG_INFO,
-	     "[DistroAV] +ndi_output_stop(name='%s', groups='%s', ...)", name,
-	     groups);
+	obs_log(LOG_INFO, "+ndi_output_stop(name='%s', groups='%s', ...)", name,
+		groups);
 	if (!o->started) {
-		blog(LOG_INFO,
-		     "[DistroAV] -ndi_output_stop(name='%s', groups='%s', ...)",
-		     name, groups);
+		obs_log(LOG_INFO,
+			"-ndi_output_stop(name='%s', groups='%s', ...)", name,
+			groups);
 		return;
 	}
 
@@ -288,11 +278,9 @@ void ndi_output_stop(void *data, uint64_t)
 	obs_output_end_data_capture(o->output);
 
 	if (o->ndi_sender) {
-		blog(LOG_INFO,
-		     "[DistroAV] +ndiLib->send_destroy(o->ndi_sender)");
+		obs_log(LOG_INFO, "+ndiLib->send_destroy(o->ndi_sender)");
 		ndiLib->send_destroy(o->ndi_sender);
-		blog(LOG_INFO,
-		     "[DistroAV] -ndiLib->send_destroy(o->ndi_sender)");
+		obs_log(LOG_INFO, "-ndiLib->send_destroy(o->ndi_sender)");
 		o->ndi_sender = nullptr;
 	}
 
@@ -309,9 +297,8 @@ void ndi_output_stop(void *data, uint64_t)
 	o->audio_channels = 0;
 	o->audio_samplerate = 0;
 
-	blog(LOG_INFO,
-	     "[DistroAV] -ndi_output_stop(name='%s', groups='%s', ...)", name,
-	     groups);
+	obs_log(LOG_INFO, "-ndi_output_stop(name='%s', groups='%s', ...)", name,
+		groups);
 }
 
 void ndi_output_destroy(void *data)
@@ -319,19 +306,17 @@ void ndi_output_destroy(void *data)
 	auto o = (ndi_output_t *)data;
 	auto name = o->ndi_name;
 	auto groups = o->ndi_groups;
-	blog(LOG_INFO,
-	     "[DistroAV] +ndi_output_destroy(name='%s', groups='%s', ...)",
-	     name, groups);
+	obs_log(LOG_INFO, "+ndi_output_destroy(name='%s', groups='%s', ...)",
+		name, groups);
+
 	if (o->audio_conv_buffer) {
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_output_destroy: freeing %zu bytes",
-		     o->audio_conv_buffer_size);
+		obs_log(LOG_INFO, "ndi_output_destroy: freeing %zu bytes",
+			o->audio_conv_buffer_size);
 		bfree(o->audio_conv_buffer);
 		o->audio_conv_buffer = nullptr;
 	}
-	blog(LOG_INFO,
-	     "[DistroAV] -ndi_output_destroy(name='%s', groups='%s', ...)",
-	     name, groups);
+	obs_log(LOG_INFO, "-ndi_output_destroy(name='%s', groups='%s', ...)",
+		name, groups);
 	bfree(o);
 }
 
@@ -387,18 +372,18 @@ void ndi_output_rawaudio(void *data, audio_data *frame)
 		audio_frame.no_channels * audio_frame.channel_stride_in_bytes;
 
 	if (data_size > o->audio_conv_buffer_size) {
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_output_rawaudio(`%s`): growing audio_conv_buffer from %zu to %zu bytes",
-		     o->ndi_name, o->audio_conv_buffer_size, data_size);
+		obs_log(LOG_INFO,
+			"ndi_output_rawaudio(`%s`): growing audio_conv_buffer from %zu to %zu bytes",
+			o->ndi_name, o->audio_conv_buffer_size, data_size);
 		if (o->audio_conv_buffer) {
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_output_rawaudio(`%s`): freeing %zu bytes",
-			     o->ndi_name, o->audio_conv_buffer_size);
+			obs_log(LOG_INFO,
+				"ndi_output_rawaudio(`%s`): freeing %zu bytes",
+				o->ndi_name, o->audio_conv_buffer_size);
 			bfree(o->audio_conv_buffer);
 		}
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_output_rawaudio(`%s`): allocating %zu bytes",
-		     o->ndi_name, data_size);
+		obs_log(LOG_INFO,
+			"ndi_output_rawaudio(`%s`): allocating %zu bytes",
+			o->ndi_name, data_size);
 		o->audio_conv_buffer = (uint8_t *)bmalloc(data_size);
 		o->audio_conv_buffer_size = data_size;
 	}

--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -214,7 +214,7 @@ const char *ndi_source_getname(void *)
 
 obs_properties_t *ndi_source_getproperties(void *)
 {
-	blog(LOG_INFO, "[DistroAV] +ndi_source_getproperties()");
+	obs_log(LOG_INFO, "+ndi_source_getproperties()");
 
 	obs_properties_t *props = obs_properties_create();
 
@@ -366,14 +366,14 @@ obs_properties_t *ndi_source_getproperties(void *)
 	obs_properties_add_group(props, "ndi", "NDI®", OBS_GROUP_NORMAL,
 				 group_ndi);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_source_getproperties()");
+	obs_log(LOG_INFO, "-ndi_source_getproperties()");
 
 	return props;
 }
 
 void ndi_source_getdefaults(obs_data_t *settings)
 {
-	blog(LOG_INFO, "[DistroAV] +ndi_source_getdefaults(…)");
+	obs_log(LOG_INFO, "+ndi_source_getdefaults(…)");
 	obs_data_set_default_int(settings, PROP_BANDWIDTH, PROP_BW_HIGHEST);
 	obs_data_set_default_string(settings, PROP_BEHAVIOR,
 				    PROP_BEHAVIOR_KEEP);
@@ -386,7 +386,7 @@ void ndi_source_getdefaults(obs_data_t *settings)
 				 PROP_YUV_SPACE_BT709);
 	obs_data_set_default_int(settings, PROP_LATENCY, PROP_LATENCY_NORMAL);
 	obs_data_set_default_bool(settings, PROP_AUDIO, true);
-	blog(LOG_INFO, "[DistroAV] -ndi_source_getdefaults(…)");
+	obs_log(LOG_INFO, "-ndi_source_getdefaults(…)");
 }
 
 void deactivate_source_output_video_texture(obs_source_t *obs_source)
@@ -418,8 +418,7 @@ void *ndi_source_thread(void *data)
 {
 	auto s = (ndi_source_t *)data;
 	auto obs_source_name = obs_source_get_name(s->obs_source);
-	blog(LOG_INFO, "[DistroAV] +ndi_source_thread(…): '%s'",
-	     obs_source_name);
+	obs_log(LOG_INFO, "'%s' +ndi_source_thread(…)", obs_source_name);
 
 	ndi_source_config_t config_most_recent;
 	ndi_source_config_t config_last_used;
@@ -469,10 +468,10 @@ void *ndi_source_thread(void *data)
 
 			recv_desc.p_ndi_recv_name =
 				config_most_recent.ndi_receiver_name;
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' ndi_receiver_name changed; Setting recv_desc.p_ndi_recv_name='%s'",
-			     obs_source_name, //
-			     recv_desc.p_ndi_recv_name);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: ndi_receiver_name changed; Setting recv_desc.p_ndi_recv_name='%s'",
+				obs_source_name, //
+				recv_desc.p_ndi_recv_name);
 		}
 
 		// Fast pointer comparison is fine here; no need for slow content comparison
@@ -485,10 +484,10 @@ void *ndi_source_thread(void *data)
 
 			recv_desc.source_to_connect_to.p_ndi_name =
 				config_most_recent.ndi_source_name;
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' ndi_source_name changed; Setting recv_desc.source_to_connect_to.p_ndi_name='%s'",
-			     obs_source_name, //
-			     recv_desc.source_to_connect_to.p_ndi_name);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: ndi_source_name changed; Setting recv_desc.source_to_connect_to.p_ndi_name='%s'",
+				obs_source_name, //
+				recv_desc.source_to_connect_to.p_ndi_name);
 		}
 
 		if (config_most_recent.bandwidth !=
@@ -513,10 +512,10 @@ void *ndi_source_thread(void *data)
 					NDIlib_recv_bandwidth_audio_only;
 				break;
 			}
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' bandwidth changed; Setting recv_desc.bandwidth='%d'",
-			     obs_source_name, //
-			     recv_desc.bandwidth);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: bandwidth changed; Setting recv_desc.bandwidth='%d'",
+				obs_source_name, //
+				recv_desc.bandwidth);
 		}
 
 		if (config_most_recent.latency != config_last_used.latency) {
@@ -530,10 +529,10 @@ void *ndi_source_thread(void *data)
 			else
 				recv_desc.color_format =
 					NDIlib_recv_color_format_fastest;
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' latency changed; Setting recv_desc.color_format='%d'",
-			     obs_source_name, //
-			     recv_desc.color_format);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: latency changed; Setting recv_desc.color_format='%d'",
+				obs_source_name, //
+				recv_desc.color_format);
 		}
 
 		if (config_most_recent.framesync_enabled !=
@@ -543,11 +542,12 @@ void *ndi_source_thread(void *data)
 
 			reset_ndi_receiver = true;
 
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' framesync changed to %s",
-			     obs_source_name, //
-			     config_most_recent.framesync_enabled ? "enabled"
-								  : "disabled");
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: framesync changed to %s",
+				obs_source_name, //
+				config_most_recent.framesync_enabled
+					? "enabled"
+					: "disabled");
 		}
 		//
 		// Check for changes that require resetting ndi_receiver: END
@@ -559,9 +559,9 @@ void *ndi_source_thread(void *data)
 		if (reset_ndi_receiver) {
 			reset_ndi_receiver = false;
 
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' reset_ndi_receiver: Resetting NDI receiver…",
-			     obs_source_name);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: reset_ndi_receiver: Resetting NDI receiver…",
+				obs_source_name);
 
 			if (ndi_frame_sync) {
 				ndiLib->framesync_destroy(ndi_frame_sync);
@@ -570,43 +570,44 @@ void *ndi_source_thread(void *data)
 
 			if (ndi_receiver) {
 #if 1
-				blog(LOG_INFO,
-				     "[DistroAV] ndi_source_thread: '%s' reset_ndi_receiver: ndiLib->recv_destroy(ndi_receiver)",
-				     obs_source_name);
+				obs_log(LOG_INFO,
+					"'%s' ndi_source_thread: reset_ndi_receiver: ndiLib->recv_destroy(ndi_receiver)",
+					obs_source_name);
 #endif
 				ndiLib->recv_destroy(ndi_receiver);
 				ndi_receiver = nullptr;
 			}
 #if 1
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' reset_ndi_receiver: recv_desc = { p_ndi_recv_name='%s', source_to_connect_to.p_ndi_name='%s' }",
-			     obs_source_name, //
-			     recv_desc.p_ndi_recv_name,
-			     recv_desc.source_to_connect_to.p_ndi_name);
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' reset_ndi_receiver: +ndi_receiver = ndiLib->recv_create_v3(&recv_desc)",
-			     obs_source_name);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: reset_ndi_receiver: recv_desc = { p_ndi_recv_name='%s', source_to_connect_to.p_ndi_name='%s' }",
+				obs_source_name, //
+				recv_desc.p_ndi_recv_name,
+				recv_desc.source_to_connect_to.p_ndi_name);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: reset_ndi_receiver: +ndi_receiver = ndiLib->recv_create_v3(&recv_desc)",
+				obs_source_name);
 #endif
 			ndi_receiver = ndiLib->recv_create_v3(&recv_desc);
 #if 1
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' reset_ndi_receiver: -ndi_receiver = ndiLib->recv_create_v3(&recv_desc)",
-			     obs_source_name);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: reset_ndi_receiver: -ndi_receiver = ndiLib->recv_create_v3(&recv_desc)",
+				obs_source_name);
 #endif
 			if (!ndi_receiver) {
-				blog(LOG_ERROR,
-				     "[DistroAV] ndi_source_thread: '%s' reset_ndi_receiver: Cannot create ndi_receiver for NDI source '%s'",
-				     obs_source_name, //
-				     recv_desc.source_to_connect_to.p_ndi_name);
+				obs_log(LOG_ERROR,
+					"'%s' ndi_source_thread: reset_ndi_receiver: Cannot create ndi_receiver for NDI source '%s'",
+					obs_source_name, //
+					recv_desc.source_to_connect_to
+						.p_ndi_name);
 				break;
 			}
 
 			// Deactivate the source output video texture when using Audio only
 			if (recv_desc.bandwidth ==
 			    NDIlib_recv_bandwidth_audio_only) {
-				blog(LOG_INFO,
-				     "[DistroAV] ndi_source_thread: '%s' reset_ndi_receiver: Audio Only: Deactivating source output video texture",
-				     obs_source_name);
+				obs_log(LOG_INFO,
+					"'%s' ndi_source_thread: reset_ndi_receiver: Audio Only: Deactivate source output video texture",
+					obs_source_name);
 				deactivate_source_output_video_texture(
 					s->obs_source);
 			}
@@ -617,24 +618,24 @@ void *ndi_source_thread(void *data)
 				timestamp_video = 0;
 
 #if 1
-				blog(LOG_INFO,
-				     "[DistroAV] ndi_source_thread: '%s' +ndi_frame_sync = ndiLib->framesync_create(ndi_receiver)",
-				     obs_source_name);
+				obs_log(LOG_INFO,
+					"'%s' ndi_source_thread: +ndi_frame_sync = ndiLib->framesync_create(ndi_receiver)",
+					obs_source_name);
 #endif
 				ndi_frame_sync =
 					ndiLib->framesync_create(ndi_receiver);
 #if 1
-				blog(LOG_INFO,
-				     "[DistroAV] ndi_source_thread: '%s' -ndi_frame_sync = ndiLib->framesync_create(ndi_receiver); ndi_frame_sync=%p",
-				     obs_source_name, //
-				     ndi_frame_sync);
+				obs_log(LOG_INFO,
+					"'%s' ndi_source_thread: -ndi_frame_sync = ndiLib->framesync_create(ndi_receiver); ndi_frame_sync=%p",
+					obs_source_name, //
+					ndi_frame_sync);
 #endif
 				if (!ndi_frame_sync) {
-					blog(LOG_ERROR,
-					     "[DistroAV] ndi_source_thread: '%s' Cannot create ndi_frame_sync for NDI source '%s'",
-					     obs_source_name, //
-					     recv_desc.source_to_connect_to
-						     .p_ndi_name);
+					obs_log(LOG_ERROR,
+						"'%s' ndi_source_thread: Cannot create ndi_frame_sync for NDI source '%s'",
+						obs_source_name, //
+						recv_desc.source_to_connect_to
+							.p_ndi_name);
 					break;
 				}
 			}
@@ -650,10 +651,11 @@ void *ndi_source_thread(void *data)
 		//
 		if (ndiLib->recv_get_no_connections(ndi_receiver) == 0) {
 #if 0
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' No connection; sleep and restart loop",
+			obs_log(LOG_INFO,
+			     "'%s' ndi_source_thread: No connection; sleep and restart loop",
 			     obs_source_name);
 #endif
+			//blog(LOG_INFO, "s");//leep");
 			std::this_thread::sleep_for(
 				std::chrono::milliseconds(100));
 			continue;
@@ -672,10 +674,10 @@ void *ndi_source_thread(void *data)
 				config_most_recent.hw_accel_enabled
 					? (char *)"<ndi_hwaccel enabled=\"true\"/>"
 					: (char *)"<ndi_hwaccel enabled=\"false\"/>";
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' hw_accel_enabled changed; Sending NDI metadata '%s'",
-			     obs_source_name, //
-			     hwAccelMetadata.p_data);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: hw_accel_enabled changed; Sending NDI metadata '%s'",
+				obs_source_name, //
+				hwAccelMetadata.p_data);
 			ndiLib->recv_send_metadata(ndi_receiver,
 						   &hwAccelMetadata);
 		}
@@ -696,12 +698,12 @@ void *ndi_source_thread(void *data)
 					config_last_used.ptz =
 						config_most_recent.ptz;
 
-					blog(LOG_INFO,
-					     "[DistroAV] ndi_source_thread: '%s' ptz changed; Sending PTZ pan=%f, tilt=%f, zoom=%f",
-					     obs_source_name, //
-					     config_most_recent.ptz.pan,
-					     config_most_recent.ptz.tilt,
-					     config_most_recent.ptz.zoom);
+					obs_log(LOG_INFO,
+						"'%s' ndi_source_thread: ptz changed; Sending PTZ pan=%f, tilt=%f, zoom=%f",
+						obs_source_name, //
+						config_most_recent.ptz.pan,
+						config_most_recent.ptz.tilt,
+						config_most_recent.ptz.zoom);
 					ndiLib->recv_ptz_pan_tilt(
 						ndi_receiver,
 						config_most_recent.ptz.pan,
@@ -722,11 +724,11 @@ void *ndi_source_thread(void *data)
 			    config_last_used.tally.on_program) {
 			config_last_used.tally = config_most_recent.tally;
 
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread: '%s' tally changed; Sending tally on_preview=%d, on_program=%d",
-			     obs_source_name, //
-			     config_most_recent.tally.on_preview,
-			     config_most_recent.tally.on_program);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread: tally changed; Sending tally on_preview=%d, on_program=%d",
+				obs_source_name, //
+				config_most_recent.tally.on_preview,
+				config_most_recent.tally.on_program);
 			ndiLib->recv_set_tally(ndi_receiver,
 					       &config_most_recent.tally);
 		}
@@ -747,7 +749,7 @@ void *ndi_source_thread(void *data)
 				1024);
 			if (audio_frame2.p_data &&
 			    (audio_frame2.timestamp > timestamp_audio)) {
-				//blog(LOG_INFO, "a");//udio_frame";
+				//blog(LOG_INFO, "a");//udio_frame");
 				timestamp_audio = audio_frame2.timestamp;
 				ndi_source_thread_process_audio2(
 					&config_most_recent, &audio_frame2,
@@ -765,7 +767,7 @@ void *ndi_source_thread(void *data)
 				NDIlib_frame_format_type_progressive);
 			if (video_frame2.p_data &&
 			    (video_frame2.timestamp > timestamp_video)) {
-				//blog(LOG_INFO, "v");//ideo_frame";
+				//blog(LOG_INFO, "v");//ideo_frame");
 				timestamp_video = video_frame2.timestamp;
 				ndi_source_thread_process_video2(
 					&config_most_recent, &video_frame2,
@@ -790,7 +792,7 @@ void *ndi_source_thread(void *data)
 				//
 				// AUDIO
 				//
-				//blog(LOG_INFO, "v");//ideo_frame";
+				//blog(LOG_INFO, "a");//udio_frame");
 				ndi_source_thread_process_audio3(
 					&config_most_recent, &audio_frame3,
 					s->obs_source, &obs_audio_frame);
@@ -804,7 +806,7 @@ void *ndi_source_thread(void *data)
 				//
 				// VIDEO
 				//
-				//blog(LOG_INFO, "v");//ideo_frame";
+				//blog(LOG_INFO, "v");//ideo_frame");
 				ndi_source_thread_process_video2(
 					&config_most_recent, &video_frame2,
 					s->obs_source, &obs_video_frame);
@@ -829,8 +831,7 @@ void *ndi_source_thread(void *data)
 		ndi_receiver = nullptr;
 	}
 
-	blog(LOG_INFO, "[DistroAV] -ndi_source_thread(…): '%s'",
-	     obs_source_name);
+	obs_log(LOG_INFO, "'%s' -ndi_source_thread(…)", obs_source_name);
 
 	return nullptr;
 }
@@ -946,9 +947,9 @@ void ndi_source_thread_process_video2(ndi_source_config_t *config,
 		break;
 
 	default:
-		blog(LOG_WARNING,
-		     "[DistroAV] warning: unsupported video pixel format: %d",
-		     ndi_video_frame->FourCC);
+		obs_log(LOG_WARNING,
+			"warning: unsupported video pixel format: %d",
+			ndi_video_frame->FourCC);
 		break;
 	}
 
@@ -981,9 +982,9 @@ void ndi_source_thread_start(ndi_source_t *s)
 {
 	s->running = true;
 	pthread_create(&s->av_thread, nullptr, ndi_source_thread, s);
-	blog(LOG_INFO,
-	     "[DistroAV] ndi_source_thread_start: '%s' Started A/V ndi_source_thread for NDI source '%s'",
-	     obs_source_get_name(s->obs_source), s->config.ndi_source_name);
+	obs_log(LOG_INFO,
+		"'%s' ndi_source_thread_start: Started A/V ndi_source_thread for NDI source '%s'",
+		obs_source_get_name(s->obs_source), s->config.ndi_source_name);
 }
 
 void ndi_source_thread_stop(ndi_source_t *s)
@@ -993,14 +994,14 @@ void ndi_source_thread_stop(ndi_source_t *s)
 		pthread_join(s->av_thread, NULL);
 		auto obs_source = s->obs_source;
 		auto obs_source_name = obs_source_get_name(obs_source);
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_source_thread_stop: '%s' Stopped A/V ndi_source_thread for NDI source '%s'",
-		     obs_source_name, s->config.ndi_source_name);
+		obs_log(LOG_INFO,
+			"'%s' ndi_source_thread_stop: Stopped A/V ndi_source_thread for NDI source '%s'",
+			obs_source_name, s->config.ndi_source_name);
 
 		if (!s->config.remember_last_frame) {
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_thread_stop: '%s' Behavior Blank Frame: Deactivating source output video texture",
-			     obs_source_name);
+			obs_log(LOG_INFO,
+				"'%s' ndi_source_thread_stop: Behavior Blank Frame: Deactivate source output video texture",
+				obs_source_name);
 			deactivate_source_output_video_texture(obs_source);
 		}
 	}
@@ -1011,7 +1012,7 @@ void ndi_source_update(void *data, obs_data_t *settings)
 	auto s = (ndi_source_t *)data;
 	auto obs_source = s->obs_source;
 	auto obs_source_name = obs_source_get_name(obs_source);
-	blog(LOG_INFO, "[DistroAV] +ndi_source_update: '%s'", obs_source_name);
+	obs_log(LOG_INFO, "'%s' +ndi_source_update(…)", obs_source_name);
 
 	s->config.ndi_source_name = obs_data_get_string(settings, PROP_SOURCE);
 	s->config.bandwidth = (int)obs_data_get_int(settings, PROP_BANDWIDTH);
@@ -1083,46 +1084,55 @@ void ndi_source_update(void *data, obs_data_t *settings)
 	s->config.tally.on_program = config->TallyProgramEnabled &&
 				     obs_source_active(obs_source);
 
-	if (strlen(s->config.ndi_source_name) > 0) {
-		if (!s->running &&
-		    (obs_source_active(obs_source) ||
-		     // source is not active but user wants to keep NDI receiver running
-		     s->config.behavior == BEHAVIOR_KEEP)) {
-
-			if (s->config.bandwidth ==
-			    NDIlib_recv_bandwidth_audio_only) {
-				blog(LOG_INFO,
-				     "[DistroAV] ndi_source_update: '%s': Audio Only: Deactivating source output video texture",
-				     obs_source_name);
-				deactivate_source_output_video_texture(
-					obs_source);
-			}
-
-			blog(LOG_INFO,
-			     "[DistroAV] ndi_source_update: '%s': Requesting Source Thread Start.",
-			     obs_source_name);
-			ndi_source_thread_start(s);
-		}
-	} else {
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_source_update: '%s': Requesting Source Thread Stop.",
-		     obs_source_name);
+	if (strlen(s->config.ndi_source_name) == 0) {
+		obs_log(LOG_INFO,
+			"'%s' ndi_source_update: No NDI Source defined; Requesting Source Thread Stop.",
+			obs_source_name);
 		ndi_source_thread_stop(s);
+	} else {
+		obs_log(LOG_INFO, "'%s' ndi_source_update: NDI Source defined.",
+			obs_source_name);
+
+		if (!s->running) {
+			//
+			// Thread is not running; start it if either:
+			// 1. the source is active
+			//    -or-
+			// 2. the behavior property is set to keep the NDI receiver running
+			//
+			if (obs_source_active(obs_source) ||
+			    s->config.behavior == BEHAVIOR_KEEP) {
+
+				if (s->config.bandwidth ==
+				    NDIlib_recv_bandwidth_audio_only) {
+					obs_log(LOG_INFO,
+						"'%s' ndi_source_update: Audio Only: Deactivate source output video texture",
+						obs_source_name);
+					deactivate_source_output_video_texture(
+						obs_source);
+				}
+
+				obs_log(LOG_INFO,
+					"'%s' ndi_source_update: Requesting Source Thread Start.",
+					obs_source_name);
+				ndi_source_thread_start(s);
+			}
+		}
 	}
 
-	blog(LOG_INFO, "[DistroAV] -ndi_source_update: '%s'", obs_source_name);
+	obs_log(LOG_INFO, "'%s' -ndi_source_update(…)", obs_source_name);
 }
 
 void ndi_source_shown(void *data)
 {
 	auto s = (ndi_source_t *)data;
 	auto obs_source_name = obs_source_get_name(s->obs_source);
-	blog(LOG_INFO, "[DistroAV] ndi_source_shown: '%s'", obs_source_name);
+	obs_log(LOG_INFO, "'%s' ndi_source_shown(…)", obs_source_name);
 	s->config.tally.on_preview = (Config::Current())->TallyPreviewEnabled;
 	if (!s->running) {
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_source_shown: '%s': Requesting Source Thread Start.",
-		     obs_source_name);
+		obs_log(LOG_INFO,
+			"'%s' ndi_source_shown: Requesting Source Thread Start.",
+			obs_source_name);
 		ndi_source_thread_start(s);
 	}
 }
@@ -1131,12 +1141,12 @@ void ndi_source_hidden(void *data)
 {
 	auto s = (ndi_source_t *)data;
 	auto obs_source_name = obs_source_get_name(s->obs_source);
-	blog(LOG_INFO, "[DistroAV] ndi_source_hidden: '%s'", obs_source_name);
+	obs_log(LOG_INFO, "'%s' ndi_source_hidden(…)", obs_source_name);
 	s->config.tally.on_preview = false;
 	if (s->config.behavior == BEHAVIOR_DISCONNECT && s->running) {
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_source_hidden: '%s': Requesting Source Thread Stop.",
-		     obs_source_name);
+		obs_log(LOG_INFO,
+			"'%s' ndi_source_hidden: Requesting Source Thread Stop.",
+			obs_source_name);
 		ndi_source_thread_stop(s);
 	}
 }
@@ -1145,13 +1155,12 @@ void ndi_source_activated(void *data)
 {
 	auto s = (ndi_source_t *)data;
 	auto obs_source_name = obs_source_get_name(s->obs_source);
-	blog(LOG_INFO, "[DistroAV] ndi_source_activated: '%s'",
-	     obs_source_name);
+	obs_log(LOG_INFO, "'%s' ndi_source_activated(…)", obs_source_name);
 	s->config.tally.on_program = (Config::Current())->TallyProgramEnabled;
 	if (!s->running) {
-		blog(LOG_INFO,
-		     "[DistroAV] ndi_source_activated: '%s' : Requesting Source Thread Start.",
-		     obs_source_name);
+		obs_log(LOG_INFO,
+			"'%s' ndi_source_activated: Requesting Source Thread Start.",
+			obs_source_name);
 		ndi_source_thread_start(s);
 	}
 }
@@ -1159,8 +1168,8 @@ void ndi_source_activated(void *data)
 void ndi_source_deactivated(void *data)
 {
 	auto s = (ndi_source_t *)data;
-	blog(LOG_INFO, "[DistroAV] ndi_source_deactivated: '%s'",
-	     obs_source_get_name(s->obs_source));
+	obs_log(LOG_INFO, "'%s' ndi_source_deactivated(…)",
+		obs_source_get_name(s->obs_source));
 	s->config.tally.on_program = false;
 }
 
@@ -1170,10 +1179,10 @@ void new_ndi_receiver_name(const char *obs_source_name,
 	if (*ndi_receiver_name) {
 		bfree(*ndi_receiver_name);
 	}
-	*ndi_receiver_name = bstrdup(
-		QString("DistroAV '%1'").arg(obs_source_name).toUtf8().data());
-	// blog(LOG_INFO,
-	//      "[DistroAV] new_ndi_receiver_name: '%s' ndi_receiver_name='%s'",
+	*ndi_receiver_name = bstrdup(QT_TO_UTF8(
+		QString("%1 '%1'").arg(PLUGIN_DISPLAY_NAME, obs_source_name)));
+	// obs_log(LOG_INFO,
+	//      "'%s' new_ndi_receiver_name: ndi_receiver_name='%s'",
 	//      obs_source_name, *ndi_receiver_name);
 }
 
@@ -1182,7 +1191,7 @@ void ndi_source_renamed(void *data, calldata_t *);
 void *ndi_source_create(obs_data_t *settings, obs_source_t *obs_source)
 {
 	auto obs_source_name = obs_source_get_name(obs_source);
-	blog(LOG_INFO, "[DistroAV] +ndi_source_create: '%s'", obs_source_name);
+	obs_log(LOG_INFO, "'%s' +ndi_source_create(…)", obs_source_name);
 
 	auto s = (ndi_source_t *)bzalloc(sizeof(ndi_source_t));
 	s->obs_source = obs_source;
@@ -1193,7 +1202,7 @@ void *ndi_source_create(obs_data_t *settings, obs_source_t *obs_source)
 
 	ndi_source_update(s, settings);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_source_create: '%s'", obs_source_name);
+	obs_log(LOG_INFO, "'%s' -ndi_source_create(…)", obs_source_name);
 
 	return s;
 }
@@ -1203,16 +1212,15 @@ void ndi_source_renamed(void *data, calldata_t *)
 	auto s = (ndi_source_t *)data;
 	auto obs_source_name = obs_source_get_name(s->obs_source);
 	new_ndi_receiver_name(obs_source_name, &(s->config.ndi_receiver_name));
-	blog(LOG_INFO,
-	     "[DistroAV] ndi_source_renamed: '%s' ndi_receiver_name='%s'",
-	     obs_source_name, s->config.ndi_receiver_name);
+	obs_log(LOG_INFO, "'%s' ndi_source_renamed: ndi_receiver_name='%s'",
+		obs_source_name, s->config.ndi_receiver_name);
 }
 
 void ndi_source_destroy(void *data)
 {
 	auto s = (ndi_source_t *)data;
 	auto obs_source_name = obs_source_get_name(s->obs_source);
-	blog(LOG_INFO, "[DistroAV] +ndi_source_destroy: '%s'", obs_source_name);
+	obs_log(LOG_INFO, "'%s' +ndi_source_destroy(…)", obs_source_name);
 
 	signal_handler_disconnect(obs_source_get_signal_handler(s->obs_source),
 				  "rename", ndi_source_renamed, s);
@@ -1225,7 +1233,7 @@ void ndi_source_destroy(void *data)
 	}
 	bfree(s);
 
-	blog(LOG_INFO, "[DistroAV] -ndi_source_destroy: '%s'", obs_source_name);
+	obs_log(LOG_INFO, "'%s' -ndi_source_destroy(…)", obs_source_name);
 }
 
 obs_source_info create_ndi_source_info()

--- a/src/obs-support/remote-text.cpp
+++ b/src/obs-support/remote-text.cpp
@@ -69,7 +69,7 @@ void RemoteTextThread::run()
 			header = curl_slist_append(header, h.c_str());
 
 #if 0
-		blog(LOG_INFO, "[DistroAV] RemoteTextThread: Requesting `%s`",
+		obs_log(LOG_INFO, "RemoteTextThread: Requesting `%s`",
 		     url.c_str());
 #endif
 		auto session = curl.get();
@@ -104,7 +104,7 @@ void RemoteTextThread::run()
 		curl_easy_getinfo(session, CURLINFO_RESPONSE_CODE,
 				  &httpStatusCode);
 #if 0
-		blog(LOG_INFO, "[DistroAV] RemoteTextThread: curlCode=%d, httpCode=%d",
+		obs_log(LOG_INFO, "RemoteTextThread: curlCode=%d, httpCode=%d",
 		     curlCode, (int)httpCode);
 #endif
 		if (curlCode != CURLE_OK) {
@@ -113,9 +113,9 @@ void RemoteTextThread::run()
 					.arg(curlCode)
 					.arg(curl_easy_strerror(curlCode))
 					.arg(error);
-			blog(LOG_WARNING,
-			     "[DistroAV] RemoteTextThread: HTTP request failed. `%s`",
-			     QT_TO_UTF8(errorData));
+			obs_log(LOG_WARNING,
+				"RemoteTextThread: HTTP request failed. `%s`",
+				QT_TO_UTF8(errorData));
 		}
 		emit Result((int)httpStatusCode, responseData, errorData);
 

--- a/src/obs-support/shared-update.cpp
+++ b/src/obs-support/shared-update.cpp
@@ -41,17 +41,16 @@ bool CalculateFileHash(const char *path, QString &hash)
 {
 	QFile file(path);
 	if (!file.open(QIODevice::ReadOnly)) {
-		blog(LOG_WARNING,
-		     "[DistroAV] CalculateFileHash: Failed to open file: `%s`",
-		     path);
+		obs_log(LOG_WARNING,
+			"CalculateFileHash: Failed to open file: `%s`", path);
 		return false;
 	}
 
 	QCryptographicHash qhash(QCryptographicHash::Sha256);
 	if (!qhash.addData(&file)) {
-		blog(LOG_WARNING,
-		     "[DistroAV] CalculateFileHash: Failed to read data from file: `%s`",
-		     path);
+		obs_log(LOG_WARNING,
+			"CalculateFileHash: Failed to read data from file: `%s`",
+			path);
 		return false;
 	}
 

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -76,16 +76,16 @@ OutputSettings *output_settings = nullptr;
 
 /**
  * @param url The url to rehost
- * @return if macro `USE_LOCALHOST` is defined then "https://127.0.0.1:5002...", otherwise url
+ * @return if command-line `--distroav-update-local[=port]` is defined then "https://127.0.0.1:[port]...", otherwise url
  */
 QString rehostUrl(const char *url)
 {
 	auto result = QString::fromUtf8(url);
-	if (Config::UpdateHost() == UpdateHostEnum::LocalEmulator) {
+	if (Config::UpdateLocalPort > 0) {
 		result.replace("https://distroav.org",
 			       QString("http://%1:%2")
 				       .arg(PLUGIN_WEB_HOST_LOCAL_EMULATOR)
-				       .arg(Config::UpdateLocalPort()));
+				       .arg(Config::UpdateLocalPort));
 	}
 	return result;
 }
@@ -190,15 +190,15 @@ bool is_module_found(const char *module_name)
 				(struct find_module_data *)param;
 			if (strcmp(data_->target_name, module_info->name) ==
 			    0) {
-				blog(LOG_INFO,
-				     "[DistroAV] is_module_found: Found module_info->name == `%s`",
-				     module_info->name);
+				obs_log(LOG_INFO,
+					"is_module_found: Found module_info->name == `%s`",
+					module_info->name);
 #if 0
-				blog(LOG_INFO,
-				     "[DistroAV] is_module_found: module_info->bin_path=`%s`",
+				obs_log(LOG_INFO,
+				     "is_module_found: module_info->bin_path=`%s`",
 				     module_info->bin_path);
-				blog(LOG_INFO,
-				     "[DistroAV] is_module_found: module_info->data_path=`%s`",
+				obs_log(LOG_INFO,
+				     "is_module_found: module_info->data_path=`%s`",
 				     module_info->data_path);
 #endif
 				data_->found = true;
@@ -210,9 +210,9 @@ bool is_module_found(const char *module_name)
 
 bool is_obsndi_installed()
 {
-	auto force = Config::DetectObsNdiForce();
-	if (force) {
-		return force == 1;
+	auto force = Config::DetectObsNdiForce;
+	if (force != 0) {
+		return force > 0;
 	}
 	return is_module_found("obs-ndi");
 }
@@ -223,19 +223,18 @@ bool is_obsndi_installed()
 
 bool obs_module_load(void)
 {
-	blog(LOG_INFO,
-	     "[DistroAV] obs_module_load: you can haz %s (Version %s)",
-	     PLUGIN_DISPLAY_NAME, PLUGIN_VERSION);
-	blog(LOG_INFO,
-	     "[DistroAV] obs_module_load: Qt Version: %s (runtime), %s (compiled)",
-	     qVersion(), QT_VERSION_STR);
+	obs_log(LOG_INFO, "obs_module_load: you can haz %s (Version %s)",
+		PLUGIN_DISPLAY_NAME, PLUGIN_VERSION);
+	obs_log(LOG_INFO,
+		"obs_module_load: Qt Version: %s (runtime), %s (compiled)",
+		qVersion(), QT_VERSION_STR);
 
 	auto config = Config::Current();
 
 	if (is_obsndi_installed()) {
-		blog(LOG_INFO,
-		     "[DistroAV] obs_module_load: OBS-NDI is detected and needs to be uninstalled before %s will load.",
-		     PLUGIN_DISPLAY_NAME);
+		obs_log(LOG_INFO,
+			"obs_module_load: OBS-NDI is detected and needs to be uninstalled before %s will load.",
+			PLUGIN_DISPLAY_NAME);
 		showCriticalUnloadingMessageBoxDelayed(
 			QTStr("NDIPlugin.ErrorObsNdiDetected.Title"),
 			QTStr("NDIPlugin.ErrorObsNdiDetected.Message")
@@ -261,9 +260,9 @@ bool obs_module_load(void)
 #else
 		message += makeLink(PLUGIN_REDIRECT_NDI_REDIST_URL);
 #endif
-		blog(LOG_ERROR,
-		     "[DistroAV] obs_module_load: ERROR - load_ndilib() failed; message=%s",
-		     QT_TO_UTF8(message));
+		obs_log(LOG_ERROR,
+			"obs_module_load: ERROR - load_ndilib() failed; message=%s",
+			QT_TO_UTF8(message));
 		showCriticalUnloadingMessageBoxDelayed(title, message);
 		return false;
 	}
@@ -275,14 +274,14 @@ bool obs_module_load(void)
 	auto initialized = ndiLib->initialize();
 #endif
 	if (!initialized) {
-		blog(LOG_ERROR,
-		     "[DistroAV] obs_module_load: ndiLib->initialize() failed; CPU unsupported by NDI library. Module won't load.");
+		obs_log(LOG_ERROR,
+			"obs_module_load: ndiLib->initialize() failed; CPU unsupported by NDI library. Module won't load.");
 		return false;
 	}
 
-	blog(LOG_INFO,
-	     "[DistroAV] obs_module_load: NDI library initialized successfully ('%s')",
-	     ndiLib->version());
+	obs_log(LOG_INFO,
+		"obs_module_load: NDI library initialized successfully ('%s')",
+		ndiLib->version());
 
 	NDIlib_find_create_t find_desc = {0};
 	find_desc.show_local_sources = true;
@@ -356,16 +355,16 @@ bool obs_module_load(void)
 
 void obs_module_post_load(void)
 {
-	blog(LOG_INFO, "[DistroAV] +obs_module_post_load()");
+	obs_log(LOG_INFO, "+obs_module_post_load()");
 
 	updateCheckStart();
 
-	blog(LOG_INFO, "[DistroAV] -obs_module_post_load()");
+	obs_log(LOG_INFO, "-obs_module_post_load()");
 }
 
 void obs_module_unload(void)
 {
-	blog(LOG_INFO, "[DistroAV] +obs_module_unload()");
+	obs_log(LOG_INFO, "+obs_module_unload()");
 
 	updateCheckStop();
 
@@ -382,7 +381,7 @@ void obs_module_unload(void)
 		delete loaded_lib;
 	}
 
-	blog(LOG_INFO, "[DistroAV] -obs_module_unload(): goodbye!");
+	obs_log(LOG_INFO, "-obs_module_unload(): goodbye!");
 }
 
 const NDIlib_v5 *load_ndilib()
@@ -428,8 +427,8 @@ const NDIlib_v5 *load_ndilib()
 		// MacOS, Windows
 		temp_path = QDir::cleanPath(
 			dir.absoluteFilePath(NDILIB_LIBRARY_NAME));
-		blog(LOG_INFO, "[DistroAV] load_ndilib: Trying '%s'",
-		     QT_TO_UTF8(QDir::toNativeSeparators(temp_path)));
+		obs_log(LOG_INFO, "load_ndilib: Trying '%s'",
+			QT_TO_UTF8(QDir::toNativeSeparators(temp_path)));
 		auto file_info = QFileInfo(temp_path);
 		if (file_info.exists() && file_info.isFile()) {
 			lib_path = temp_path;
@@ -438,34 +437,33 @@ const NDIlib_v5 *load_ndilib()
 #endif
 	}
 	if (!lib_path.isEmpty()) {
-		blog(LOG_INFO,
-		     "[DistroAV] load_ndilib: Found '%s'; attempting to load NDI library...",
-		     QT_TO_UTF8(QDir::toNativeSeparators(lib_path)));
+		obs_log(LOG_INFO,
+			"load_ndilib: Found '%s'; attempting to load NDI library...",
+			QT_TO_UTF8(QDir::toNativeSeparators(lib_path)));
 		loaded_lib = new QLibrary(lib_path, nullptr);
 		if (loaded_lib->load()) {
-			blog(LOG_INFO,
-			     "[DistroAV] load_ndilib: NDI library loaded successfully");
+			obs_log(LOG_INFO,
+				"load_ndilib: NDI library loaded successfully");
 			NDIlib_v5_load_ lib_load =
 				reinterpret_cast<NDIlib_v5_load_>(
 					loaded_lib->resolve("NDIlib_v5_load"));
 			if (lib_load != nullptr) {
-				blog(LOG_INFO,
-				     "[DistroAV] load_ndilib: NDIlib_v5_load found");
+				obs_log(LOG_INFO,
+					"load_ndilib: NDIlib_v5_load found");
 				return lib_load();
 			} else {
-				blog(LOG_ERROR,
-				     "[DistroAV] load_ndilib: ERROR: NDIlib_v5_load not found in loaded library");
+				obs_log(LOG_ERROR,
+					"load_ndilib: ERROR: NDIlib_v5_load not found in loaded library");
 			}
 		} else {
-			blog(LOG_ERROR,
-			     "[DistroAV] load_ndilib: ERROR: QLibrary returned the following error: '%s'",
-			     QT_TO_UTF8(loaded_lib->errorString()));
+			obs_log(LOG_ERROR,
+				"load_ndilib: ERROR: QLibrary returned the following error: '%s'",
+				QT_TO_UTF8(loaded_lib->errorString()));
 			delete loaded_lib;
 			loaded_lib = nullptr;
 		}
 	}
 
-	blog(LOG_ERROR,
-	     "[DistroAV] load_ndilib: ERROR: Can't find the NDI library");
+	obs_log(LOG_ERROR, "load_ndilib: ERROR: Can't find the NDI library");
 	return nullptr;
 }

--- a/src/plugin-support.c.in
+++ b/src/plugin-support.c.in
@@ -15,8 +15,31 @@
 	along with this program; if not, see <https://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#include <plugin-support.h>
+#include "plugin-support.h"
+
+int LOG_LEVEL = LOG_NONE;
 
 const char *PLUGIN_NAME = "@CMAKE_PROJECT_NAME@";
 const char *PLUGIN_DISPLAY_NAME = "@PLUGIN_DISPLAY_NAME@";
 const char *PLUGIN_VERSION = "@CMAKE_PROJECT_VERSION@";
+
+extern void blogva(int log_level, const char *format, va_list args);
+
+void obs_log(int log_level, const char *format, ...)
+{
+	if (log_level >= LOG_LEVEL) {
+		size_t length = 4 + strlen(PLUGIN_NAME) + strlen(format);
+
+		char *template = malloc(length + 1);
+
+		snprintf(template, length, "[%s] %s", PLUGIN_NAME, format);
+
+		va_list(args);
+
+		va_start(args, format);
+		blogva(log_level, template, args);
+		va_end(args);
+
+		free(template);
+	}
+}

--- a/src/plugin-support.h
+++ b/src/plugin-support.h
@@ -21,9 +21,21 @@
 extern "C" {
 #endif
 
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define LOG_NONE -1
+#define LOG_VERBOSE 500
+
+extern int LOG_LEVEL;
+
 extern const char *PLUGIN_NAME;
 extern const char *PLUGIN_DISPLAY_NAME;
 extern const char *PLUGIN_VERSION;
+
+void obs_log(int log_level, const char *format, ...);
 
 #ifdef __cplusplus
 }

--- a/src/preview-output.cpp
+++ b/src/preview-output.cpp
@@ -47,8 +47,8 @@ void preview_output_init(const char *default_name, const char *default_groups)
 	if (context.output)
 		return;
 
-	blog(LOG_INFO, "[DistroAV] preview_output_init('%s', '%s')",
-	     default_name, default_groups);
+	obs_log(LOG_INFO, "preview_output_init('%s', '%s')", default_name,
+		default_groups);
 
 	obs_data_t *output_settings = obs_data_create();
 	obs_data_set_string(output_settings, "ndi_name", default_name);
@@ -64,9 +64,9 @@ void preview_output_start(const char *output_name, const char *output_groups)
 	if (context.enabled || !context.output)
 		return;
 
-	blog(LOG_INFO,
-	     "[DistroAV] preview_output_start: starting NDI preview output with name '%s'",
-	     output_name);
+	obs_log(LOG_INFO,
+		"preview_output_start: starting NDI preview output with name '%s'",
+		output_name);
 
 	obs_get_video_info(&context.ovi);
 
@@ -130,8 +130,7 @@ void preview_output_start(const char *output_name, const char *output_groups)
 	obs_output_start(context.output);
 	context.enabled = true;
 
-	blog(LOG_INFO,
-	     "[DistroAV] preview_output_start: started NDI preview output");
+	obs_log(LOG_INFO, "preview_output_start: started NDI preview output");
 }
 
 void preview_output_stop()
@@ -139,8 +138,7 @@ void preview_output_stop()
 	if (!context.enabled)
 		return;
 
-	blog(LOG_INFO,
-	     "[DistroAV] preview_output_stop: stopping NDI preview output");
+	obs_log(LOG_INFO, "preview_output_stop: stopping NDI preview output");
 
 	obs_output_stop(context.output);
 
@@ -161,13 +159,12 @@ void preview_output_stop()
 
 	context.enabled = false;
 
-	blog(LOG_INFO,
-	     "[DistroAV] preview_output_stop: stopped NDI preview output");
+	obs_log(LOG_INFO, "preview_output_stop: stopped NDI preview output");
 }
 
 void preview_output_deinit()
 {
-	blog(LOG_INFO, "[DistroAV] preview_output_deinit()");
+	obs_log(LOG_INFO, "preview_output_deinit()");
 
 	obs_output_release(context.output);
 
@@ -182,7 +179,7 @@ bool preview_output_is_enabled()
 
 void on_preview_scene_changed(enum obs_frontend_event event, void *param)
 {
-	blog(LOG_INFO, "[DistroAV] on_preview_scene_changed(%d)", event);
+	obs_log(LOG_INFO, "on_preview_scene_changed(%d)", event);
 	auto ctx = (struct preview_output *)param;
 	switch (event) {
 	case OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED:


### PR DESCRIPTION
I am changing from direct `blog(...)` calls to the template "recommended" `obs_log(...)`.  
This cleans up the code a little bit to get rid of the redundant "[DistroAV] " prefixes.  
This also lets the code gate the log levels a little better.  
I have waffled on doing this several times but I am finally biting the bullet on this.

`blog` already uses `va_list`, so this is not much worse.  
The only "worse" part is the dynamically allocated and freed buffer used by `snprintf`.  
Hopefully this does not thrash memory too much.
