### PR TITLE
Check for ndiLib when destroying receiver and framesync

### DIFF
--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -776,12 +776,12 @@ void *ndi_source_thread(void *data)
 	//
 
 	if (ndi_frame_sync) {
-		ndiLib->framesync_destroy(ndi_frame_sync);
+		if (ndiLib) ndiLib->framesync_destroy(ndi_frame_sync);
 		ndi_frame_sync = nullptr;
 	}
 
 	if (ndi_receiver) {
-		ndiLib->recv_destroy(ndi_receiver);
+		if (ndiLib) ndiLib->recv_destroy(ndi_receiver);
 		ndi_receiver = nullptr;
 	}
 


### PR DESCRIPTION
The new 100ms delay after check for no_of_connections == 0 can mean the thread loop will exit after the ndiLib has been destroyed in module unload. Adding a check for a valid ndiLib link before calling destroy methods will keep shutdown from crashing.