### PR TITLE
Recognize ndi_source_name change

### DIFF
--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -958,7 +958,7 @@ void ndi_source_thread_start(ndi_source_t *s)
 	pthread_create(&s->av_thread, nullptr, ndi_source_thread, s);
 	obs_log(LOG_INFO,
 		"'%s' ndi_source_thread_start: Started A/V ndi_source_thread for NDI source '%s'",
-		obs_source_get_name(s->obs_source), s->config.ndi_source_name);
+		obs_source_get_name(s->obs_source), s->config.ndi_source_name.c_str());
 }
 
 void ndi_source_thread_stop(ndi_source_t *s)
@@ -970,7 +970,7 @@ void ndi_source_thread_stop(ndi_source_t *s)
 		auto obs_source_name = obs_source_get_name(obs_source);
 		obs_log(LOG_INFO,
 			"'%s' ndi_source_thread_stop: Stopped A/V ndi_source_thread for NDI source '%s'",
-			obs_source_name, s->config.ndi_source_name);
+			obs_source_name, s->config.ndi_source_name.c_str());
 
 		if (!s->config.remember_last_frame) {
 			obs_log(LOG_INFO,
@@ -1102,7 +1102,7 @@ void ndi_source_update(void *data, obs_data_t *settings)
 	} else {
 		obs_log(LOG_INFO,
 			"'%s' ndi_source_update: NDI Source '%s' selected.",
-			obs_source_name, s->config.ndi_source_name);
+			obs_source_name, s->config.ndi_source_name.c_str());
 		if (s->running) {
 			//
 			// Thread is running; notify it if it needs to reset the NDI receiver

--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -96,7 +96,7 @@ typedef struct ndi_source_config_t {
 	// Changes that require the NDI receiver to be reset:
 	//
 	char *ndi_receiver_name;
-	const char *ndi_source_name;
+	std::string ndi_source_name;
 	int bandwidth;
 	int latency;
 	bool framesync_enabled;
@@ -462,7 +462,7 @@ void *ndi_source_thread(void *data)
 			// Update recv_desc.source_to_connect_to.p_ndi_name
 			//
 			recv_desc.source_to_connect_to.p_ndi_name =
-				s->config.ndi_source_name;
+				s->config.ndi_source_name.c_str();
 			obs_log(LOG_DEBUG,
 				"'%s' ndi_source_thread: reset_ndi_receiver; Setting recv_desc.source_to_connect_to.p_ndi_name='%s'",
 				obs_source_name, //
@@ -1006,7 +1006,7 @@ void ndi_source_update(void *data, obs_data_t *settings)
 	bool reset_ndi_receiver = false;
 
 	auto new_ndi_source_name = obs_data_get_string(settings, PROP_SOURCE);
-	reset_ndi_receiver |= safe_strcmp(s->config.ndi_source_name,
+	reset_ndi_receiver |= safe_strcmp(s->config.ndi_source_name.c_str(),
 					  new_ndi_source_name) != 0;
 	s->config.ndi_source_name = new_ndi_source_name;
 
@@ -1094,7 +1094,7 @@ void ndi_source_update(void *data, obs_data_t *settings)
 	s->config.tally.on_program = config->TallyProgramEnabled &&
 				     obs_source_active(obs_source);
 
-	if (strlen(s->config.ndi_source_name) == 0) {
+	if (strlen(s->config.ndi_source_name.c_str()) == 0) {
 		obs_log(LOG_INFO,
 			"'%s' ndi_source_update: No NDI Source selected; Requesting Source Thread Stop.",
 			obs_source_name);

--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -958,7 +958,8 @@ void ndi_source_thread_start(ndi_source_t *s)
 	pthread_create(&s->av_thread, nullptr, ndi_source_thread, s);
 	obs_log(LOG_INFO,
 		"'%s' ndi_source_thread_start: Started A/V ndi_source_thread for NDI source '%s'",
-		obs_source_get_name(s->obs_source), s->config.ndi_source_name.c_str());
+		obs_source_get_name(s->obs_source),
+		s->config.ndi_source_name.c_str());
 }
 
 void ndi_source_thread_stop(ndi_source_t *s)


### PR DESCRIPTION
When the source name changes, the ndi receiver would not get reset. This was because the ndi_source_name is a char * in the config and the code was in effect comparing with itself the second time through the update code. Fixed by changing ndi_source_name to a std::string.