### PR TITLE
Remove the use of deprecated QT methods allowing it to build on ArchL…

### DIFF
--- a/src/forms/update.cpp
+++ b/src/forms/update.cpp
@@ -169,7 +169,7 @@ public:
 
 		auto utcDateTime = QDateTime::fromString(
 			pluginUpdateInfo.releaseDate, Qt::ISODate);
-		utcDateTime.setTimeSpec(Qt::UTC);
+		utcDateTime = utcDateTime.toUTC();
 		auto formattedUtcDateTime =
 			utcDateTime.toString("yyyy-MM-dd hh:mm:ss 'UTC'");
 		textTemp = QString("<h3>%1</h3>")
@@ -183,7 +183,7 @@ public:
 		ui->checkBoxAutoCheckForUpdates->setChecked(
 			config->AutoCheckForUpdates());
 		connect(ui->checkBoxAutoCheckForUpdates,
-			&QCheckBox::stateChanged, this, [](int state) {
+			&QCheckBox::checkStateChanged, this, [](int state) {
 				Config::Current(false)->AutoCheckForUpdates(
 					state == Qt::Checked);
 			});


### PR DESCRIPTION
…inux

When I tried to build this plugin on ArchLinux I was getting errors on those methods. Here is a proposed fix