### PR TITLE
Auto remove obs-ndi - Windows

### DIFF
--- a/cmake/windows/resources/installer-Windows.iss.in
+++ b/cmake/windows/resources/installer-Windows.iss.in
@@ -1,4 +1,4 @@
-#define MyAppName "@CMAKE_PROJECT_NAME@"
+#define MyAppName "@PLUGIN_DISPLAY_NAME@"
 #define MyAppVersion "@CMAKE_PROJECT_VERSION@"
 #define MyAppPublisher "@PLUGIN_AUTHOR@"
 #define MyAppURL "@PLUGIN_WEBSITE@"

--- a/cmake/windows/resources/installer-Windows.iss.in
+++ b/cmake/windows/resources/installer-Windows.iss.in
@@ -78,7 +78,8 @@ end;
 // Remove old OBS-NDI conflicting plugin - by Trouffman for DistroA https://github.com/DistroAV/DistroAV/
 
 // CAREFUL : this target the old AppID.
-const UninstallRegisterPath = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A9039243-4FE7-45E7-8B11-7DC1ACB67B9D}_is1';
+const UninstallRegisteryPath411up = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A9039243-4FE7-45E7-8B11-7DC1ACB67B9D}_is1';
+const UninstallRegisteryPath410 = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{CD703FE5-1F2C-4837-BD3D-DD840D83C3E3}_is1';
 
 function GetOldAppUninstallerPath(Param: String): String;
 var
@@ -86,11 +87,18 @@ var
 // Param is required to be used in other sections.
 begin
   result := '';
-  // Check primary registry location
-  if ( RegQueryStringValue(HKLM, UninstallRegisterPath, 'UninstallString', UninstallerPathRegistry) ) then
+  // Check primary registry location version 4.11+
+  if ( RegQueryStringValue(HKLM, UninstallRegisteryPath411up, 'UninstallString', UninstallerPathRegistry) ) then
       result := RemoveQuotes(UninstallerPathRegistry)
   // Check alternative Registry location
-  else if ( RegQueryStringValue(HKCU, UninstallRegisterPath, 'UninstallString', UninstallerPathRegistry) ) then
+  else if ( RegQueryStringValue(HKCU, UninstallRegisteryPath411up, 'UninstallString', UninstallerPathRegistry) ) then
+      result := RemoveQuotes(UninstallerPathRegistry)
+
+  // Check primary registry location version 4.10
+  else if ( RegQueryStringValue(HKLM, UninstallRegisteryPath410, 'UninstallString', UninstallerPathRegistry) ) then
+      result := RemoveQuotes(UninstallerPathRegistry)
+  // Check alternative Registry location
+  else if ( RegQueryStringValue(HKCU, UninstallRegisteryPath410, 'UninstallString', UninstallerPathRegistry) ) then
       result := RemoveQuotes(UninstallerPathRegistry);
 end;
 

--- a/cmake/windows/resources/installer-Windows.iss.in
+++ b/cmake/windows/resources/installer-Windows.iss.in
@@ -75,31 +75,30 @@ begin
 end;
 
 
-// Remove old OBS-NDI conflicting plugin - by Trouffman for DistroA https://github.com/DistroAV/DistroAV/
-
+// Remove old OBS-NDI conflicting plugin - by Trouffman for DistroAV https://github.com/DistroAV/DistroAV/ & https://github.com/DistroAV/DistroAV/wiki/OBS%E2%80%90NDI-Is-Now-DistroAV
 // CAREFUL : this target the old AppID.
-const UninstallRegisteryPath411up = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A9039243-4FE7-45E7-8B11-7DC1ACB67B9D}_is1';
-const UninstallRegisteryPath410 = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{CD703FE5-1F2C-4837-BD3D-DD840D83C3E3}_is1';
+const UninstallRegisteryKey411up = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A9039243-4FE7-45E7-8B11-7DC1ACB67B9D}_is1';
+const UninstallRegisteryKey410 = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{CD703FE5-1F2C-4837-BD3D-DD840D83C3E3}_is1';
 
 function GetOldAppUninstallerPath(Param: String): String;
 var
   UninstallerPathRegistry: String;
-// Param is required to be used in other sections.
+// At least one Param string is required to use this fucntion with {code:}, can be empty.
 begin
-  result := '';
+  Result := '';
   // Check primary registry location version 4.11+
-  if ( RegQueryStringValue(HKLM, UninstallRegisteryPath411up, 'UninstallString', UninstallerPathRegistry) ) then
-      result := RemoveQuotes(UninstallerPathRegistry)
+  if ( RegQueryStringValue(HKLM, UninstallRegisteryKey411up, 'UninstallString', UninstallerPathRegistry) ) then
+      Result := RemoveQuotes(UninstallerPathRegistry)
   // Check alternative Registry location
-  else if ( RegQueryStringValue(HKCU, UninstallRegisteryPath411up, 'UninstallString', UninstallerPathRegistry) ) then
-      result := RemoveQuotes(UninstallerPathRegistry)
+  else if ( RegQueryStringValue(HKCU, UninstallRegisteryKey411up, 'UninstallString', UninstallerPathRegistry) ) then
+      Result := RemoveQuotes(UninstallerPathRegistry)
 
   // Check primary registry location version 4.10
-  else if ( RegQueryStringValue(HKLM, UninstallRegisteryPath410, 'UninstallString', UninstallerPathRegistry) ) then
-      result := RemoveQuotes(UninstallerPathRegistry)
+  else if ( RegQueryStringValue(HKLM, UninstallRegisteryKey410, 'UninstallString', UninstallerPathRegistry) ) then
+      Result := RemoveQuotes(UninstallerPathRegistry)
   // Check alternative Registry location
-  else if ( RegQueryStringValue(HKCU, UninstallRegisteryPath410, 'UninstallString', UninstallerPathRegistry) ) then
-      result := RemoveQuotes(UninstallerPathRegistry);
+  else if ( RegQueryStringValue(HKCU, UninstallRegisteryKey410, 'UninstallString', UninstallerPathRegistry) ) then
+      Result := RemoveQuotes(UninstallerPathRegistry);
 end;
 
 function UninstallOldAppAvailable(): Boolean;

--- a/cmake/windows/resources/installer-Windows.iss.in
+++ b/cmake/windows/resources/installer-Windows.iss.in
@@ -29,10 +29,6 @@ Source: "..\release\Package\*"; DestDir: "{app}"; Flags: ignoreversion recursesu
 Source: "..\LICENSE"; Flags: dontcopy
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
-; Could be used to "nullify" obs-ndi.dll (replace with an empty file) then delete this file at the end of the installation
-; Source: "{app}\obs-ndi.dll"; DestDir: "{app}"; Flags: deleteafterinstall
-; Source: "{app}\obs-ndi.pdb"; DestDir: "{app}"; Flags: deleteafterinstall 
-
 [Icons]
 Name: "{group}\{cm:ProgramOnTheWeb,{#MyAppName}}"; Filename: "{#MyAppURL}"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
@@ -79,16 +75,15 @@ begin
 end;
 
 
-// Remove OBS-NDI - by @Trouffman for DistroAV
+// Remove old OBS-NDI conflicting plugin - by Trouffman for DistroA https://github.com/DistroAV/DistroAV/
 
-// Based on 4.14.0 AppId
+// CAREFUL : this target the old AppID.
 const UninstallRegisterPath = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A9039243-4FE7-45E7-8B11-7DC1ACB67B9D}_is1';
 
-// Find out if the old App uninstaller exists
 function GetOldAppUninstallerPath(Param: String): String;
 var
   UninstallerPathRegistry: String;
-// Param is required but not used.
+// Param is required to be used in other sections.
 begin
   result := '';
   // Check primary registry location
@@ -97,14 +92,8 @@ begin
   // Check alternative Registry location
   else if ( RegQueryStringValue(HKCU, UninstallRegisterPath, 'UninstallString', UninstallerPathRegistry) ) then
       result := RemoveQuotes(UninstallerPathRegistry);
- // else
-      // No old-app uninstaller found
-      // Assume no old-app exist or it is a manual install
-  // end;
 end;
 
-
-// Check for the old App Uninstaller
 function UninstallOldAppAvailable(): Boolean;
 begin
   if (GetOldAppUninstallerPath('') <> '') then Result := True else Result := False;

--- a/cmake/windows/resources/installer-Windows.iss.in
+++ b/cmake/windows/resources/installer-Windows.iss.in
@@ -29,9 +29,25 @@ Source: "..\release\Package\*"; DestDir: "{app}"; Flags: ignoreversion recursesu
 Source: "..\LICENSE"; Flags: dontcopy
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
+; Could be used to "nullify" obs-ndi.dll (replace with an empty file) then delete this file at the end of the installation
+; Source: "{app}\obs-ndi.dll"; DestDir: "{app}"; Flags: deleteafterinstall
+; Source: "{app}\obs-ndi.pdb"; DestDir: "{app}"; Flags: deleteafterinstall 
+
 [Icons]
 Name: "{group}\{cm:ProgramOnTheWeb,{#MyAppName}}"; Filename: "{#MyAppURL}"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+
+[InstallDelete]
+; Remove previous obs-ndi plugin files (the hard-way)
+Type: filesandordirs; Name: "{app}\data\obs-plugins\obs-ndi\"
+Type: files; Name: "{app}\obs-plugins\64bit\obs-ndi.dll"
+Type: files; Name: "{app}\obs-plugins\64bit\obs-ndi.pdb"
+
+[Run]
+; This uninstall the old obs-ndi after installation but before the final dialog when installing DistroAV
+Filename: "{code:GetOldAppUninstallerPath}"; Parameters: "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"; Check: UninstallOldAppAvailable ;  Description: "Silently Uninstall OBS-NDI"
+; Dev-note: Cannot use : Flags: skipifdoesntexist >> it only takes absolute filename.
+
 
 [Code]
 procedure InitializeWizard();
@@ -62,3 +78,34 @@ begin
     Result := InstallPath
 end;
 
+
+// Remove OBS-NDI - by @Trouffman for DistroAV
+
+// Based on 4.14.0 AppId
+const UninstallRegisterPath = 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{A9039243-4FE7-45E7-8B11-7DC1ACB67B9D}_is1';
+
+// Find out if the old App uninstaller exists
+function GetOldAppUninstallerPath(Param: String): String;
+var
+  UninstallerPathRegistry: String;
+// Param is required but not used.
+begin
+  result := '';
+  // Check primary registry location
+  if ( RegQueryStringValue(HKLM, UninstallRegisterPath, 'UninstallString', UninstallerPathRegistry) ) then
+      result := RemoveQuotes(UninstallerPathRegistry)
+  // Check alternative Registry location
+  else if ( RegQueryStringValue(HKCU, UninstallRegisterPath, 'UninstallString', UninstallerPathRegistry) ) then
+      result := RemoveQuotes(UninstallerPathRegistry);
+ // else
+      // No old-app uninstaller found
+      // Assume no old-app exist or it is a manual install
+  // end;
+end;
+
+
+// Check for the old App Uninstaller
+function UninstallOldAppAvailable(): Boolean;
+begin
+  if (GetOldAppUninstallerPath('') <> '') then Result := True else Result := False;
+end;


### PR DESCRIPTION
This PR aim to solve challenge with:
- Installation challenge when upgrading from OBS-NDI to DistroAV
- Reduce support request due to uncommon instillation path
- Simplify Upgrade Process for Windows

Target Usage:
- Windows Installer

The PR use
- Self-contained script (PASCAL) in the InnoSetup process

Expected behavior:
- Identify the location of the uninstaller for OBS-NDI
- Trigger a silent uninstall
- Install DistroAV
- Remove left-over files & directory
* obs-ndi.dll
* obs-ndi.pdb
* obs-ndi data folder (used to store translations files)


Some notes (useful for general knowledge and future reference):
## Use of InnoSetup [InstallDelete] Section
[Official Doc](https://documentation.help/Inno-Setup/topic_installdeletesection.htm) says this is processed as a first step in the installation process.
* It Delete the known obs-ndi files
* This also delete files that where manually installed

**This is a step to discuss! While this target exclusively obs-ndi files, we should highlight it.**


## If no uninstaller can be found this will proceed with regular installation
Leverage the [Run] Section to trigger the uninstall of OBS-NDI if the uninstaller path is known after the installation.

1. Look up in registry if the unsintaller for OBS-NDI exists
2. Execute the known uninstaller silently

## Why the need for a Check and not use "Flags: skipifdoesntexist"
Flags: skipifdoesntexist only support absolute Path and will not work with dynamic path.


# Tested:
- Windows 11
- OBS-NDI 4.11 / 4.12 / 4.13 / 4.14


