### PR TITLE
Add a log entry with the exact path to the old OBS-NDI plugin file

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -188,21 +188,15 @@ bool is_module_found(const char *module_name)
 		[](void *param, const struct obs_module_info2 *module_info) {
 			struct find_module_data *data_ =
 				(struct find_module_data *)param;
-			if (stricmp(data_->target_name, module_info->name) ==
+			if (strcmp(data_->target_name, module_info->name) ==
 			    0) {
-				obs_log(LOG_WARNING,
+				obs_log(LOG_INFO,
 					"is_module_found: `%s` found at `%s`",
 					module_info->name,
 					module_info->bin_path);
-				obs_log(LOG_INFO,
-					"is_module_found: Found module_info->name == `%s`",
-					module_info->name);
-				obs_log(LOG_EBUG,
-				     "is_module_found: module_info->bin_path=`%s`",
-				     module_info->bin_path);
 				obs_log(LOG_DEBUG,
-				     "is_module_found: module_info->data_path=`%s`",
-				     module_info->data_path);
+					"is_module_found: module_info->data_path=`%s`",
+					module_info->data_path);
 				data_->found = true;
 			}
 		},

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -194,17 +194,15 @@ bool is_module_found(const char *module_name)
 					"is_module_found: `%s` found at `%s`",
 					module_info->name,
 					module_info->bin_path);
-#if 0
 				obs_log(LOG_INFO,
 					"is_module_found: Found module_info->name == `%s`",
 					module_info->name);
-				obs_log(LOG_INFO,
+				obs_log(LOG_EBUG,
 				     "is_module_found: module_info->bin_path=`%s`",
 				     module_info->bin_path);
-				obs_log(LOG_INFO,
+				obs_log(LOG_DEBUG,
 				     "is_module_found: module_info->data_path=`%s`",
 				     module_info->data_path);
-#endif
 				data_->found = true;
 			}
 		},

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -188,10 +188,10 @@ bool is_module_found(const char *module_name)
 		[](void *param, const struct obs_module_info2 *module_info) {
 			struct find_module_data *data_ =
 				(struct find_module_data *)param;
-			if (strcmp(data_->target_name, module_info->name) ==
+			if (stricmp(data_->target_name, module_info->name) ==
 			    0) {
 				obs_log(LOG_WARNING,
-					"is_module_found: `%s` found at `%s` and '%s'",
+					"is_module_found: `%s` found at `%s`",
 					module_info->name,
 					module_info->bin_path);
 #if 0
@@ -201,7 +201,6 @@ bool is_module_found(const char *module_name)
 				obs_log(LOG_INFO,
 				     "is_module_found: module_info->bin_path=`%s`",
 				     module_info->bin_path);
-
 				obs_log(LOG_INFO,
 				     "is_module_found: module_info->data_path=`%s`",
 				     module_info->data_path);

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -190,13 +190,18 @@ bool is_module_found(const char *module_name)
 				(struct find_module_data *)param;
 			if (strcmp(data_->target_name, module_info->name) ==
 			    0) {
+				obs_log(LOG_WARNING,
+				     "is_module_found: `%s` found at `%s` and '%s'",
+					 module_info->name,
+				     module_info->bin_path);
+#if 0
 				obs_log(LOG_INFO,
 					"is_module_found: Found module_info->name == `%s`",
 					module_info->name);
-#if 0
 				obs_log(LOG_INFO,
 				     "is_module_found: module_info->bin_path=`%s`",
 				     module_info->bin_path);
+
 				obs_log(LOG_INFO,
 				     "is_module_found: module_info->data_path=`%s`",
 				     module_info->data_path);

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -190,10 +190,18 @@ bool is_module_found(const char *module_name)
 				(struct find_module_data *)param;
 			if (strcmp(data_->target_name, module_info->name) ==
 			    0) {
+
+                // Privacy tweak : Replace the absolute path to the user's home directory with a relative path
+				QString bin_path = QString::fromUtf8(module_info->bin_path);
+                QString home_path = QDir::homePath();
+                bin_path.replace(home_path, "[Redacted User Home Path]");
+
 				obs_log(LOG_INFO,
 					"is_module_found: `%s` found at `%s`",
 					module_info->name,
-					module_info->bin_path);
+					bin_path.toUtf8().constData());
+				// To revert to full absolute path, use module_info->bin_path
+
 				obs_log(LOG_DEBUG,
 					"is_module_found: module_info->data_path=`%s`",
 					module_info->data_path);

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -191,17 +191,23 @@ bool is_module_found(const char *module_name)
 			if (strcmp(data_->target_name, module_info->name) ==
 			    0) {
 
-                // Privacy tweak : Replace the absolute path to the user's home directory with a relative path
-				QString bin_path = QString::fromUtf8(module_info->bin_path);
-                QString home_path = QDir::homePath();
-                bin_path.replace(home_path, "[Redacted User Home Path]");
+				// Privacy tweak : Replace the absolute path to the user's home directory with a relative path
+				QString bin_path = QString::fromUtf8(
+					module_info->bin_path);
+				QString home_path = QDir::homePath();
+				bin_path.replace(home_path,
+						 "[Redacted User Home Path]");
 
 				obs_log(LOG_INFO,
 					"is_module_found: `%s` found at `%s`",
 					module_info->name,
 					bin_path.toUtf8().constData());
-				// To revert to full absolute path, use module_info->bin_path
 
+				// DEBUG logging will output the absolute path.
+				obs_log(LOG_DEBUG,
+					"is_module_found: module_info->data_path=`%s`",
+					module_info->bin_path);
+				data_->found = true;
 				obs_log(LOG_DEBUG,
 					"is_module_found: module_info->data_path=`%s`",
 					module_info->data_path);

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -191,9 +191,9 @@ bool is_module_found(const char *module_name)
 			if (strcmp(data_->target_name, module_info->name) ==
 			    0) {
 				obs_log(LOG_WARNING,
-				     "is_module_found: `%s` found at `%s` and '%s'",
-					 module_info->name,
-				     module_info->bin_path);
+					"is_module_found: `%s` found at `%s` and '%s'",
+					module_info->name,
+					module_info->bin_path);
 #if 0
 				obs_log(LOG_INFO,
 					"is_module_found: Found module_info->name == `%s`",


### PR DESCRIPTION
This adds a log entry with the exact path to the old OBS-NDI plugin file to help with diagnosing support request for issues like "DistroAV still detect OBS-NDI".

The message to look for in the OBS log is : 

```
DistroAV] is_module_found: `obs-ndi` found at `/Users/[USER]/Library/Application Support/obs-studio/plugins/obs-ndi.plugin/Contents/MacOS/obs-ndi` and '/Users/[USER]/Library/Application Support/obs-studio/plugins/obs-ndi.plugin/Contents/Resources'
[DistroAV] obs_module_load: OBS-NDI is detected and needs to be uninstalled before DistroAV will load.
```

This should then help in the Troubleshooting guide as well : https://github.com/DistroAV/DistroAV/wiki/OBS%E2%80%90NDI-Is-Now-DistroAV

