### PR TITLE
Synchronize VLC audio with video in dedicated NDI output filter

### DIFF
--- a/src/ndi-filter.cpp
+++ b/src/ndi-filter.cpp
@@ -200,7 +200,7 @@ void ndi_filter_offscreen_render(void *data, uint32_t, uint32_t)
 
 		video_frame output_frame;
 		if (video_output_lock_frame(f->video_output, &output_frame, 1,
-					    os_gettime_ns())) {
+					    obs_get_video_frame_time())) {
 			if (f->video_data) {
 				gs_stagesurface_unmap(f->stagesurface);
 				f->video_data = nullptr;
@@ -241,8 +241,8 @@ void ndi_filter_update(void *data, obs_data_t *settings)
 		send_desc.p_groups = groups;
 	else
 		send_desc.p_groups = nullptr;
-	send_desc.clock_video = false;
-	send_desc.clock_audio = false;
+	send_desc.clock_video = true;
+	send_desc.clock_audio = true;
 
 	if (!f->is_audioonly) {
 		pthread_mutex_lock(&f->ndi_sender_video_mutex);


### PR DESCRIPTION
This is to fix issue [1164](https://github.com/DistroAV/DistroAV/issues/1164).

The video output by a dedicated NDI output filter when added to a VLC source showed a 1.777 second delay compared to the audio. 

This was happening because of two problems in the ndi-filter.cpp code:
1. The timestamp of the video was being overridden by the current time in ndi_filter_offscreen_render. 
2. The NDI library was not told to synchronize the audio and video when the sender was created.

It appears as though the problem was unique to VLC. When the filter was put on a Media Source with the same file, everything was in sync. VLC is delivering video to OBS at a delayed offset and no effort was being done to resync the audio and video in the filter. In fact the filter was actually overwriting the video time stamps making it impossible to synchronize on output.

Another by product of this bug was with 60fps VLC sources. Audio was only being sent through randomly, mostly not at all. So with this fix, 60fps video is output with the correct sound, and in sync.