### PR TITLE
Fix the NDI Preview Output issue introduced in 1198

### DIFF
--- a/src/forms/output-settings.cpp
+++ b/src/forms/output-settings.cpp
@@ -183,15 +183,23 @@ void OutputSettings::onFormAccepted()
 
 	config->AutoCheckForUpdates(ui->checkBoxAutoCheckForUpdates->isChecked());
 
+	// Output settings for debugging & diagnosis
+	obs_log(LOG_INFO,
+		"Output Settings set to MainEnabled='%d', MainName='%s', MainGroup='%s', PreviewEnabled='%d', PreviewName='%s', PreviewGroup='%s'",
+		config->OutputEnabled, config->OutputName.toUtf8().constData(), config->PreviewOutputGroups.toUtf8().constData(), config->PreviewOutputEnabled,
+		config->PreviewOutputName.toUtf8().constData(), config->PreviewOutputGroups.toUtf8().constData());
+
 	config->Save();
 
 	if ((last_config.OutputEnabled != config->OutputEnabled) || (last_config.OutputName != config->OutputName) ||
 	    (last_config.OutputGroups != config->OutputGroups)) {
+		obs_log(LOG_INFO, "Initializing Main output");
 		main_output_init();
 	}
 	if ((last_config.PreviewOutputEnabled != config->PreviewOutputEnabled) ||
 	    (last_config.PreviewOutputName != config->PreviewOutputName) ||
 	    (last_config.PreviewOutputGroups != config->PreviewOutputGroups)) {
+		obs_log(LOG_INFO, "Initializing Preview output");
 		preview_output_init();
 	}
 }

--- a/src/forms/output-settings.cpp
+++ b/src/forms/output-settings.cpp
@@ -186,7 +186,8 @@ void OutputSettings::onFormAccepted()
 	// Output settings for debugging & diagnosis
 	obs_log(LOG_INFO,
 		"Output Settings set to MainEnabled='%d', MainName='%s', MainGroup='%s', PreviewEnabled='%d', PreviewName='%s', PreviewGroup='%s'",
-		config->OutputEnabled, config->OutputName.toUtf8().constData(), config->PreviewOutputGroups.toUtf8().constData(), config->PreviewOutputEnabled,
+		config->OutputEnabled, config->OutputName.toUtf8().constData(),
+		config->PreviewOutputGroups.toUtf8().constData(), config->PreviewOutputEnabled,
 		config->PreviewOutputName.toUtf8().constData(), config->PreviewOutputGroups.toUtf8().constData());
 
 	config->Save();

--- a/src/preview-output.cpp
+++ b/src/preview-output.cpp
@@ -221,18 +221,17 @@ void preview_output_init()
 		obs_data_set_string(output_settings, "ndi_groups", QT_TO_UTF8(output_groups));
 
 		obs_data_set_bool(output_settings, "uses_audio",
-			false); // Preview has no audio
+				  false); // Preview has no audio
 		context.output = obs_output_create("ndi_output", "NDI Preview Output", output_settings, nullptr);
 		obs_data_release(output_settings);
 		if (context.output) {
-			obs_log(LOG_INFO, "preview_output_init: Successfully created NDI Preview Output '%s'", QT_TO_UTF8(output_name));
+			obs_log(LOG_INFO, "preview_output_init: Successfully created NDI Preview Output '%s'",
+				QT_TO_UTF8(output_name));
 
 			// Start handling "remote" start/stop events (ex: from obs-websocket)
 			auto sh = obs_output_get_signal_handler(context.output);
-			signal_handler_connect( //
-				sh, "start", on_preview_output_started, nullptr);
-			signal_handler_connect( //
-				sh, "stop", on_preview_output_stopped, nullptr);
+			signal_handler_connect(sh, "start", on_preview_output_started, nullptr);
+			signal_handler_connect(sh, "stop", on_preview_output_stopped, nullptr);
 
 			context.ndi_name = output_name;
 			context.ndi_groups = output_groups;
@@ -245,7 +244,6 @@ void preview_output_init()
 
 	obs_log(LOG_INFO, "-preview_output_init()");
 }
-
 
 void on_preview_scene_changed(enum obs_frontend_event event, void *param)
 {

--- a/src/preview-output.cpp
+++ b/src/preview-output.cpp
@@ -212,53 +212,40 @@ void preview_output_init()
 	auto output_groups = config->PreviewOutputGroups;
 	auto is_enabled = config->PreviewOutputEnabled;
 
-	if (output_name.isEmpty() || //
-	    (output_name != context.ndi_name) || output_groups != context.ndi_groups) {
-		preview_output_deinit();
+	preview_output_deinit();
 
-		if (!output_name.isEmpty()) {
-			obs_log(LOG_INFO, "preview_output_init: creating NDI preview output '%s'",
-				QT_TO_UTF8(output_name));
-			obs_data_t *output_settings = obs_data_create();
-			obs_data_set_string(output_settings, "ndi_name", QT_TO_UTF8(output_name));
-			obs_data_set_string(output_settings, "ndi_groups", QT_TO_UTF8(output_groups));
+	if (is_enabled && !output_name.isEmpty()) {
+		obs_log(LOG_INFO, "preview_output_init: creating NDI Preview Output '%s'", QT_TO_UTF8(output_name));
+		obs_data_t *output_settings = obs_data_create();
+		obs_data_set_string(output_settings, "ndi_name", QT_TO_UTF8(output_name));
+		obs_data_set_string(output_settings, "ndi_groups", QT_TO_UTF8(output_groups));
 
-			obs_data_set_bool(output_settings, "uses_audio",
-					  false); // Preview has no audio
+		obs_data_set_bool(output_settings, "uses_audio",
+			false); // Preview has no audio
+		context.output = obs_output_create("ndi_output", "NDI Preview Output", output_settings, nullptr);
+		obs_data_release(output_settings);
+		if (context.output) {
+			obs_log(LOG_INFO, "preview_output_init: Successfully created NDI Preview Output '%s'", QT_TO_UTF8(output_name));
 
-			context.output =
-				obs_output_create("ndi_output", "NDI Preview Output", output_settings, nullptr);
-			obs_data_release(output_settings);
-			if (context.output) {
-				obs_log(LOG_INFO, "preview_output_init: successfully created NDI preview output '%s'",
-					QT_TO_UTF8(output_name));
+			// Start handling "remote" start/stop events (ex: from obs-websocket)
+			auto sh = obs_output_get_signal_handler(context.output);
+			signal_handler_connect( //
+				sh, "start", on_preview_output_started, nullptr);
+			signal_handler_connect( //
+				sh, "stop", on_preview_output_stopped, nullptr);
 
-				// Start handling "remote" start/stop events (ex: from obs-websocket)
-				auto sh = obs_output_get_signal_handler(context.output);
-				signal_handler_connect( //
-					sh, "start", on_preview_output_started, nullptr);
-				signal_handler_connect( //
-					sh, "stop", on_preview_output_stopped, nullptr);
-
-				context.ndi_name = output_name;
-				context.ndi_groups = output_groups;
-			} else {
-				obs_log(LOG_ERROR, "preview_output_init: failed to create NDI preview output '%s'",
-					QT_TO_UTF8(output_name));
-			}
-		}
-	}
-
-	if (context.is_running != is_enabled) {
-		if (is_enabled) {
-			preview_output_start();
+			context.ndi_name = output_name;
+			context.ndi_groups = output_groups;
 		} else {
-			preview_output_stop();
+			obs_log(LOG_ERROR, "preview_output_init: failed to create NDI Preview Output '%s'",
+				QT_TO_UTF8(output_name));
 		}
+		preview_output_start();
 	}
 
 	obs_log(LOG_INFO, "-preview_output_init()");
 }
+
 
 void on_preview_scene_changed(enum obs_frontend_event event, void *param)
 {


### PR DESCRIPTION
This PR address the following :

- Fix the bug introduced in PR #1198 
- Added a log Entry to display the configuration submitted as a one-liner


How this fix the problem ?

- The Preview-output.cpp was not, modified to reflect the changes integrated in main-output.cpp

General hope is that the 2 codebase are extremely similar (with some extra code in Preview for specifics in there)

This bring the codebase to be similar for the approach & logic on both Main output and Preview output
