### PR TITLE
Update Plugin dependencies to OBS-Deps 2025-03-06

### DIFF
--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -35,7 +35,7 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@17/bin" >> $GITHUB_PATH
+        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@19/bin" >> $GITHUB_PATH
         brew install --quiet zsh
         echo ::endgroup::
 
@@ -50,11 +50,11 @@ runs:
         : Run clang-format 🐉
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        print ::group::Install clang-format-17
-        brew install --quiet obsproject/tools/clang-format@17
+        print ::group::Install clang-format-19
+        brew install --quiet obsproject/tools/clang-format@19
         print ::endgroup::
 
-        print ::group::Run clang-format-17
+        print ::group::Run clang-format-19
         local -a changes=(${(s:,:)CHANGED_FILES//[\[\]\'\"]/})
         ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${changes}
         print ::endgroup::

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -33,24 +33,24 @@ invoke_formatter() {
 
   case ${formatter} {
     clang)
-      if (( ${+commands[clang-format-17]} )) {
-        local formatter=clang-format-17
+      if (( ${+commands[clang-format-19]} )) {
+        local formatter=clang-format-19
       } elif (( ${+commands[clang-format]} )) {
         local formatter=clang-format
       } else {
-        log_error "No viable clang-format version found (required 17.0.3)"
+        log_error "No viable clang-format version found (required 19.1.1)"
         exit 2
       }
 
       local -a formatter_version=($(${formatter} --version))
 
-      if ! is-at-least 17.0.3 ${formatter_version[-1]}; then
-        log_error "clang-format is not version 17.0.3 or above (found ${formatter_version[-1]}."
+      if ! is-at-least 19.1.1 ${formatter_version[-1]}; then
+        log_error "clang-format is not version 19.1.1 or above (found ${formatter_version[-1]}."
         exit 2
       fi
 
-      if ! is-at-least ${formatter_version[-1]} 17.0.3; then
-        log_error "clang-format is more recent than version 17.0.3 (found ${formatter_version[-1]})."
+      if ! is-at-least ${formatter_version[-1]} 19.1.1; then
+        log_error "clang-format is more recent than version 19.1.1 (found ${formatter_version[-1]})."
         exit 2
       fi
 

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,33 +1,33 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "31.0.0",
+            "version": "31.0.3",
             "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "a22966ff07aba38833ba57c36c9e0d190d083be5dec5048d0a60cd9e6b997242",
-                "windows-x64": "e8434dcee06f1702f0a0bbd1489296c77116fc51356835c3af4a6ed21b1e1c74"
+                "macos": "299bc7e55af949b15c3d45634c414c995d5d01f460fceb30d04e5d5c781dbe4b",
+                "windows-x64": "790c0f8af8db9a06832bb6020e42af0121f717297505b41cb63573238733f551"
             }
         },
         "prebuilt": {
-            "version": "2024-09-12",
+            "version": "2025-03-06",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built obs-deps",
             "hashes": {
-                "macos": "c857b211ee378772994b632036e1e5befe66b37e85286cb8e3cefc1435d5220a",
-                "windows-x64": "d4a4f194591766891ad3c0b267deec3c4b85239c8fe557273559927456aeedbb"
+                "macos": "e32bd7dbfef37931147781d8d657a4328bdcf1148008980539c07d4a18b54965",
+                "windows-x64": "22d9f923eb6d2cbdde1ff64efb9638a88629ba23a4b70ed7a52e98a81b740275"
             }
         },
         "qt6": {
-            "version": "2024-09-12",
+            "version": "2025-03-06",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos": "34a2de6b7f4d4d58fc5a15a4dba49a61d81a4045d0cedfc1a1f08c0dfb8047cf",
-                "windows-x64": "4d15ce13dbb0a8a2cabcce5ae0da5e80ee589b482a61b2025378465c1da32c4f"
+                "macos": "51bb5e2e546443ae442f74870a2c0973f1c07d2b5628cd1d530d53ff3f668f04",
+                "windows-x64": "84f83f1c3656b53a7c4ba8f8248818ba8684786e3e47123b679406e42d8b6a54"
             },
             "debugSymbols": {
-                "windows-x64": "dad2351a5c9cd438168e1ed8fb453a2534532252edb555f1001a5e8eb3f1bbd4"
+                "windows-x64": "32afba76af47f6fb2d8aa1b90b981b56cc2f2b9a5552934ad5446ddc20dec2a9"
             }
         }
     },

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,12 +1,12 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "31.0.3",
-            "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
+            "version": "31.0.0-fix",
+            "baseUrl": "https://github.com/distroav/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "299bc7e55af949b15c3d45634c414c995d5d01f460fceb30d04e5d5c781dbe4b",
-                "windows-x64": "790c0f8af8db9a06832bb6020e42af0121f717297505b41cb63573238733f551"
+                "macos": "badf8839e65b00d74440d6f7dc2e48639717c6f3709c95be88214775dffde292",
+                "windows-x64": "1baf7fbf0bbb3769133572fe4f826c15bbccf498d4d6e2c7f75017c3612590fd"
             }
         },
         "prebuilt": {

--- a/src/forms/update.cpp
+++ b/src/forms/update.cpp
@@ -156,7 +156,7 @@ public:
 		ui->labelReleaseNotes->setText(textTemp);
 
 		auto utcDateTime = QDateTime::fromString(pluginUpdateInfo.releaseDate, Qt::ISODate);
-		utcDateTime.setTimeSpec(Qt::UTC);
+		utcDateTime.setTimeZone(QTimeZone::UTC);
 		auto formattedUtcDateTime = utcDateTime.toString("yyyy-MM-dd hh:mm:ss 'UTC'");
 		textTemp = QString("<h3>%1</h3>").arg(Str("NDIPlugin.Update.ReleaseDate"));
 		ui->labelReleaseDate->setText(textTemp);
@@ -165,7 +165,7 @@ public:
 		ui->textReleaseNotes->setMarkdown(pluginUpdateInfo.releaseNotes);
 
 		ui->checkBoxAutoCheckForUpdates->setChecked(config->AutoCheckForUpdates());
-		connect(ui->checkBoxAutoCheckForUpdates, &QCheckBox::stateChanged, this,
+		connect(ui->checkBoxAutoCheckForUpdates, &QCheckBox::checkState(), this,
 			[](int state) { Config::Current(false)->AutoCheckForUpdates(state == Qt::Checked); });
 
 		connect(ui->buttonSkipThisVersion, &QPushButton::clicked, this, [this, pluginUpdateInfo]() {

--- a/src/forms/update.cpp
+++ b/src/forms/update.cpp
@@ -42,6 +42,7 @@ Inspiration(s):
 #include <QPointer>
 #include <QSslSocket>
 #include <QTimer>
+#include <QTimeZone>
 #include <QUrlQuery>
 
 #define UPDATE_TIMEOUT_SEC 10

--- a/src/forms/update.cpp
+++ b/src/forms/update.cpp
@@ -109,11 +109,11 @@ PluginUpdateInfo::PluginUpdateInfo(const int httpStatusCode_, const QString &res
 	versionCurrent = QVersionNumber::fromString(PLUGIN_VERSION);
 
 #if 0
-	// For testing purposes only
-	fakeVersionLatest = true;
-	versionLatest = QVersionNumber(versionCurrent.majorVersion(),
-				       versionCurrent.minorVersion() + 1,
-				       versionCurrent.microVersion());
+	 // For testing purposes only
+	 fakeVersionLatest = true;
+	 versionLatest = QVersionNumber(versionCurrent.majorVersion(),
+						versionCurrent.minorVersion() + 1,
+						versionCurrent.microVersion());
 #else
 	versionLatest = QVersionNumber::fromString(releaseTag);
 #endif
@@ -166,8 +166,14 @@ public:
 		ui->textReleaseNotes->setMarkdown(pluginUpdateInfo.releaseNotes);
 
 		ui->checkBoxAutoCheckForUpdates->setChecked(config->AutoCheckForUpdates());
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+		connect(ui->checkBoxAutoCheckForUpdates, &QCheckBox::checkStateChanged, this,
+			[](int state) { Config::Current(false)->AutoCheckForUpdates(state == Qt::Checked); });
+#else
 		connect(ui->checkBoxAutoCheckForUpdates, &QCheckBox::stateChanged, this,
 			[](int state) { Config::Current(false)->AutoCheckForUpdates(state == Qt::Checked); });
+#endif
 
 		connect(ui->buttonSkipThisVersion, &QPushButton::clicked, this, [this, pluginUpdateInfo]() {
 			Config::Current(false)->SkipUpdateVersion(pluginUpdateInfo.versionLatest);
@@ -209,16 +215,16 @@ QString GetObsCurrentModuleSHA256()
 	auto module = obs_current_module();
 	auto module_binary_path = obs_get_module_binary_path(module);
 #if 0
-	obs_log(LOG_INFO,
-	     "GetObsCurrentModuleSHA256: module_binary_path=`%s`",
-	     module_binary_path);
+	 obs_log(LOG_INFO,
+		  "GetObsCurrentModuleSHA256: module_binary_path=`%s`",
+		  module_binary_path);
 #endif
 	QString module_hash_sha256;
 	auto success = CalculateFileHash(module_binary_path, module_hash_sha256);
 #if 0
-	obs_log(LOG_INFO,
-	     "GetObsCurrentModuleSHA256: module_hash_sha256=`%s`",
-	     QT_TO_UTF8(module_hash_sha256));
+	 obs_log(LOG_INFO,
+		  "GetObsCurrentModuleSHA256: module_hash_sha256=`%s`",
+		  QT_TO_UTF8(module_hash_sha256));
 #endif
 	return success ? module_hash_sha256 : "";
 }
@@ -226,48 +232,48 @@ QString GetObsCurrentModuleSHA256()
 //#define UPDATE_REQUEST_QT
 #ifdef UPDATE_REQUEST_QT
 /*
-On 2024/07/06 @paulpv asked on OBS Discord #development and @RytoEX confirmed
-that OBS removed TLS support from Qt:
-https://discord.com/channels/348973006581923840/374636084883095554/1259188627699925167
-> @paulpv Q: Why does obs-deps/deps.qt set -DINPUT_openssl:STRING=no?
->	Is there some problem letting Qt use OpenSSL?
->	When I try to call QNetworkAccessManager.get("https://www.github.com") in my plugin,
->	I get a bunch of `No functional TLS backend was found`, `No TLS backend is available`, and
->	`TLS initialization failed` errors; my code works fine on http urls.
-https://discord.com/channels/348973006581923840/374636084883095554/1259193095652638879
-> @RytoEX A: We accidentally disabled copying the Qt TLS backends. It'll be fixed in a future release. 
->	It's on my backlog of "local branches that fix this that haven't been PR'd".
->	We decided intentionally to opt for the native TLS backends for Qt on Windows and macOS,
->	but see other messages where copying it got accidentally disabled.
-
-Options:
-1. Wait for OBS to fix this: Unknown how long this will be.
-	I think the place to watch for changes that fix this is:
-	* https://github.com/obsproject/obs-deps/blob/master/deps.qt/qt6.ps1
-	* https://github.com/obsproject/obs-deps/blob/master/deps.qt/qt6.zsh
-	* Or one of RytoEX's branches:
-	  https://github.com/RytoEX/obs-studio/branches
-2. Compile DistroAV's own Qt6 dep w/ TLS enabled: No thanks!
-3. Make only http requests; Don't make https requests:
-	Ignoring the security concerns, this works when testing against the emulator but won't work for
-	non-emulator (actual cloud) due to http://distroav.org auto-redirecting to https://distroav.org.
-	My original thought was that even though https requests are failing for TLS reasons, http
-	requests are still working fine and this code can use those until the TLS issue is fixed.
-	I could swear that http requests to firebase ussed to work fine.
-	But latest testing shows that http requests are auto forwarding to https, so it looks like this
-	https/TLS problem cannot be avoided by calling just http. :/
-	Until OBS adds back TLS support, this code will have to resort to using non-Qt https requests.
-4. Make https requests a non-Qt way (ex: "libcurl"):
-	OBS does this:
-		https://github.com/obsproject/obs-studio/tree/master/UI/update
-		https://github.com/obsproject/obs-studio/blob/master/UI/update/shared-update.cpp
-		https://github.com/obsproject/obs-studio/blob/master/UI/remote-text.cpp
-	occ-ai/obs-backgroundremoval does things a little different:
-		https://github.com/occ-ai/obs-backgroundremoval/tree/main/src/update-checker
-	Neither of these are highly complicated, but it is silly this has to be done and I
-	would prefer to write little to no knowlingly future throwaway code (see Option #1).
-5. Direct calls to Firebase Functions: the problem with this is "how to cancel any pending function call"?
-*/
+ On 2024/07/06 @paulpv asked on OBS Discord #development and @RytoEX confirmed
+ that OBS removed TLS support from Qt:
+ https://discord.com/channels/348973006581923840/374636084883095554/1259188627699925167
+ > @paulpv Q: Why does obs-deps/deps.qt set -DINPUT_openssl:STRING=no?
+ >	Is there some problem letting Qt use OpenSSL?
+ >	When I try to call QNetworkAccessManager.get("https://www.github.com") in my plugin,
+ >	I get a bunch of `No functional TLS backend was found`, `No TLS backend is available`, and
+ >	`TLS initialization failed` errors; my code works fine on http urls.
+ https://discord.com/channels/348973006581923840/374636084883095554/1259193095652638879
+ > @RytoEX A: We accidentally disabled copying the Qt TLS backends. It'll be fixed in a future release. 
+ >	It's on my backlog of "local branches that fix this that haven't been PR'd".
+ >	We decided intentionally to opt for the native TLS backends for Qt on Windows and macOS,
+ >	but see other messages where copying it got accidentally disabled.
+ 
+ Options:
+ 1. Wait for OBS to fix this: Unknown how long this will be.
+	 I think the place to watch for changes that fix this is:
+	 * https://github.com/obsproject/obs-deps/blob/master/deps.qt/qt6.ps1
+	 * https://github.com/obsproject/obs-deps/blob/master/deps.qt/qt6.zsh
+	 * Or one of RytoEX's branches:
+	   https://github.com/RytoEX/obs-studio/branches
+ 2. Compile DistroAV's own Qt6 dep w/ TLS enabled: No thanks!
+ 3. Make only http requests; Don't make https requests:
+	 Ignoring the security concerns, this works when testing against the emulator but won't work for
+	 non-emulator (actual cloud) due to http://distroav.org auto-redirecting to https://distroav.org.
+	 My original thought was that even though https requests are failing for TLS reasons, http
+	 requests are still working fine and this code can use those until the TLS issue is fixed.
+	 I could swear that http requests to firebase ussed to work fine.
+	 But latest testing shows that http requests are auto forwarding to https, so it looks like this
+	 https/TLS problem cannot be avoided by calling just http. :/
+	 Until OBS adds back TLS support, this code will have to resort to using non-Qt https requests.
+ 4. Make https requests a non-Qt way (ex: "libcurl"):
+	 OBS does this:
+		 https://github.com/obsproject/obs-studio/tree/master/UI/update
+		 https://github.com/obsproject/obs-studio/blob/master/UI/update/shared-update.cpp
+		 https://github.com/obsproject/obs-studio/blob/master/UI/remote-text.cpp
+	 occ-ai/obs-backgroundremoval does things a little different:
+		 https://github.com/occ-ai/obs-backgroundremoval/tree/main/src/update-checker
+	 Neither of these are highly complicated, but it is silly this has to be done and I
+	 would prefer to write little to no knowlingly future throwaway code (see Option #1).
+ 5. Direct calls to Firebase Functions: the problem with this is "how to cancel any pending function call"?
+ */
 QNetworkRequest *update_request = nullptr;
 QPointer<QNetworkReply> update_reply = nullptr;
 #else
@@ -468,26 +474,26 @@ bool updateCheckStart(UserRequestCallback userRequestCallback)
 #endif
 
 #if 0
-	//qputenv("QT_LOGGING_RULES", "qt.network.ssl=true");
-	obs_log(LOG_INFO,
-		"updateCheckStart: QSslSocket{ supportsSsl=%s, sslLibraryBuildVersionString=`%s`, sslLibraryVersionString=`%s`}",
-		QSslSocket::supportsSsl() ? "true" : "false",
-		QT_TO_UTF8(QSslSocket::sslLibraryBuildVersionString()),
-		QT_TO_UTF8(QSslSocket::sslLibraryVersionString()));
-	/*
-	The above should output something like:
-	```
-	info: updateCheckStart: QSslSocket{ supportsSsl=true, sslLibraryBuildVersionString=`OpenSSL 1.1.1l  24 Aug 2021`, sslLibraryVersionString=`OpenSSL 1.1.1l  24 Aug 2021`}	
-	```
-	Instead it is outputting:
-	```
-	warning: No functional TLS backend was found
-	warning: No functional TLS backend was found
-	warning: No functional TLS backend was found
-	info: updateCheckStart: QSslSocket{ supportsSsl=false, sslLibraryBuildVersionString=``, sslLibraryVersionString=``}
-	```
-	This appears to confirm that OBS' Qt is not built with SSL support. :(
-	*/
+	 //qputenv("QT_LOGGING_RULES", "qt.network.ssl=true");
+	 obs_log(LOG_INFO,
+		 "updateCheckStart: QSslSocket{ supportsSsl=%s, sslLibraryBuildVersionString=`%s`, sslLibraryVersionString=`%s`}",
+		 QSslSocket::supportsSsl() ? "true" : "false",
+		 QT_TO_UTF8(QSslSocket::sslLibraryBuildVersionString()),
+		 QT_TO_UTF8(QSslSocket::sslLibraryVersionString()));
+	 /*
+	 The above should output something like:
+	 ```
+	 info: updateCheckStart: QSslSocket{ supportsSsl=true, sslLibraryBuildVersionString=`OpenSSL 1.1.1l  24 Aug 2021`, sslLibraryVersionString=`OpenSSL 1.1.1l  24 Aug 2021`}	
+	 ```
+	 Instead it is outputting:
+	 ```
+	 warning: No functional TLS backend was found
+	 warning: No functional TLS backend was found
+	 warning: No functional TLS backend was found
+	 info: updateCheckStart: QSslSocket{ supportsSsl=false, sslLibraryBuildVersionString=``, sslLibraryVersionString=``}
+	 ```
+	 This appears to confirm that OBS' Qt is not built with SSL support. :(
+	 */
 #endif
 
 #ifdef UPDATE_REQUEST_QT
@@ -542,23 +548,23 @@ bool updateCheckStart(UserRequestCallback userRequestCallback)
 				 timer->deleteLater();
 				 manager->deleteLater();
 			 });
-	timer->start(UPDATE_TIMEOUT_SEC * 1000));
-	update_reply = manager->get(*update_request);
+	 timer->start(UPDATE_TIMEOUT_SEC * 1000));
+	 update_reply = manager->get(*update_request);
 #else
 	QObject::connect(
 		update_request, &RemoteTextThread::Result, main_window,
 		[userRequestCallback](int httpStatusCode, const QString &responseData, const QString &errorData) {
 #if 0
-			obs_log(LOG_INFO,
-			     "updateCheckStart: Result: httpStatusCode=%d, responseData=`%s`, errorData=`%s`",
-			     httpCode, QT_TO_UTF8(responseData),
-			     QT_TO_UTF8(errorData));
+			 obs_log(LOG_INFO,
+				  "updateCheckStart: Result: httpStatusCode=%d, responseData=`%s`, errorData=`%s`",
+				  httpCode, QT_TO_UTF8(responseData),
+				  QT_TO_UTF8(errorData));
 #endif
 			onCheckForUpdateNetworkFinish(httpStatusCode, responseData, errorData, userRequestCallback);
 		},
 		Qt::QueuedConnection);
 	update_request->start();
 #endif
-	obs_log(LOG_INFO, "-%s", QT_TO_UTF8(methodSignature));
-	return true;
+	 obs_log(LOG_INFO, "-%s", QT_TO_UTF8(methodSignature));
+	 return true;
 }

--- a/src/forms/update.cpp
+++ b/src/forms/update.cpp
@@ -166,7 +166,7 @@ public:
 		ui->textReleaseNotes->setMarkdown(pluginUpdateInfo.releaseNotes);
 
 		ui->checkBoxAutoCheckForUpdates->setChecked(config->AutoCheckForUpdates());
-		connect(ui->checkBoxAutoCheckForUpdates, &QCheckBox::checkState(), this,
+		connect(ui->checkBoxAutoCheckForUpdates, &QCheckBox::stateChanged, this,
 			[](int state) { Config::Current(false)->AutoCheckForUpdates(state == Qt::Checked); });
 
 		connect(ui->buttonSkipThisVersion, &QPushButton::clicked, this, [this, pluginUpdateInfo]() {


### PR DESCRIPTION
This PR is "ahead" of the obs-plugin-template but relies only on tagged release by master OBS Project.

- Prebuilt & QT6 pre-built : 2025-03-06

This is aimed to stay as close as possible to OBS Studio and be ready (or contribute to the obs-plugintemplate)



This is not intended to be merged until fully tested to not move away too much from the obs-plugintemplate.