### PR TITLE
Add proper UYVA support

### DIFF
--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -742,8 +742,11 @@ void ndi_source_thread_process_video2(ndi_source_config_t *config, NDIlib_video_
 		break;
 
 	case NDIlib_FourCC_type_UYVY:
-	case NDIlib_FourCC_type_UYVA:
 		obs_video_frame->format = VIDEO_FORMAT_UYVY;
+		break;
+		
+	case NDIlib_FourCC_type_UYVA:
+		obs_video_frame->format = VIDEO_FORMAT_UYVA;
 		break;
 
 	case NDIlib_FourCC_type_I420:
@@ -775,6 +778,11 @@ void ndi_source_thread_process_video2(ndi_source_config_t *config, NDIlib_video_
 	obs_video_frame->height = ndi_video_frame->yres;
 	obs_video_frame->linesize[0] = ndi_video_frame->line_stride_in_bytes;
 	obs_video_frame->data[0] = ndi_video_frame->p_data;
+
+	if (ndi_video_frame->FourCC == NDIlib_FourCC_video_type_UYVA) {
+		obs_video_frame->linesize[1] = ndi_video_frame->xres;
+		obs_video_frame->data[1] = (uint8_t *)ndi_video_frame->p_data + (ndi_video_frame->data_size_in_bytes * ndi_video_frame->yres);
+	}
 
 	video_format_get_parameters(config->yuv_colorspace, config->yuv_range, obs_video_frame->color_matrix,
 				    obs_video_frame->color_range_min, obs_video_frame->color_range_max);


### PR DESCRIPTION
Currently UYVA is being treated as UYVY in DistroAV.

This makes sense as OBS does not currently support NDI's special UYVA format and the way UYVA is handled is in 2 planes ([Reference](https://docs.ndi.video/all/developing-with-ndi/sdk/frame-types)):
- The first plane is effectively just UYVY, meaning that images will still retain their color, **however**
- The second plane has the alpha information

Without support for said second plane the image will just look like it's on a black background:
![image](https://github.com/user-attachments/assets/936e8a6f-1ce5-41c3-b516-29f3d8060a24)

However, adding support in both OBS through [this PR](https://github.com/obsproject/obs-studio/pull/12125) and also within DistroAV will make it look correctly:
![image](https://github.com/user-attachments/assets/5e51a4b7-54eb-4bf9-90ff-4c022f5ed201)

This PR will not build without the OBS PR merging first as it tries to access a new video format.