### PR TITLE
Remove dual declaration of ndi_output_update

### DIFF
--- a/src/ndi-output.cpp
+++ b/src/ndi-output.cpp
@@ -111,7 +111,22 @@ void ndi_output_getdefaults(obs_data_t *settings)
 	obs_log(LOG_DEBUG, "-ndi_output_getdefaults()");
 }
 
-void ndi_output_update(void *data, obs_data_t *settings);
+void ndi_output_update(void *data, obs_data_t *settings)
+{
+	auto o = (ndi_output_t *)data;
+	auto name = obs_data_get_string(settings, "ndi_name");
+	auto groups = obs_data_get_string(settings, "ndi_groups");
+	obs_log(LOG_DEBUG, "ndi_output_update(name='%s', groups='%s', ...)", name, groups);
+
+	o->ndi_name = name;
+	o->ndi_groups = groups;
+	o->uses_video = obs_data_get_bool(settings, "uses_video");
+	o->uses_audio = obs_data_get_bool(settings, "uses_audio");
+
+	obs_log(LOG_INFO, "NDI Output Updated. '%s'", name);
+	obs_log(LOG_DEBUG, "ndi_output_update(name='%s', groups='%s', uses_video='%s', uses_audio='%s')", name, groups,
+		o->uses_video ? "true" : "false", o->uses_audio ? "true" : "false");
+}
 
 void *ndi_output_create(obs_data_t *settings, obs_output_t *output)
 {
@@ -227,23 +242,6 @@ bool ndi_output_start(void *data)
 	obs_log(LOG_DEBUG, "-ndi_output_start(name='%s', groups='%s'...)", name, groups);
 
 	return o->started;
-}
-
-void ndi_output_update(void *data, obs_data_t *settings)
-{
-	auto o = (ndi_output_t *)data;
-	auto name = obs_data_get_string(settings, "ndi_name");
-	auto groups = obs_data_get_string(settings, "ndi_groups");
-	obs_log(LOG_DEBUG, "ndi_output_update(name='%s', groups='%s', ...)", name, groups);
-
-	o->ndi_name = name;
-	o->ndi_groups = groups;
-	o->uses_video = obs_data_get_bool(settings, "uses_video");
-	o->uses_audio = obs_data_get_bool(settings, "uses_audio");
-
-	obs_log(LOG_INFO, "NDI Output Updated. '%s'", name);
-	obs_log(LOG_DEBUG, "ndi_output_update(name='%s', groups='%s', uses_video='%s', uses_audio='%s')", name, groups,
-		o->uses_video ? "true" : "false", o->uses_audio ? "true" : "false");
 }
 
 void ndi_output_stop(void *data, uint64_t)


### PR DESCRIPTION
# Change type
Code clean-up

# Issue resolved
This solve the issue of non-relevant entry log with empty values.
Simplify codebase

# Change proposed
This remove a non-used declaration of the ndi_output_update that is declared twice in the ndi-output logic.

# Expected impact
- none as this was declared twice, already surprising it did not created error earlier.

# Test / things to check
As this is touching the Output logic new need to test:
- Main / Preview output still works properly
- NDI Output filter still works properly

# Root cause
https://github.com/DistroAV/DistroAV/blob/9290c99461e498ca66f25eade485744ed692d985/src/ndi-output.cpp#L114

This was added back in the refactoring of 4.12 by @paulpv and looks like a placeholder that was not removed before commit (there was quite some changes at that time!)

