### PR TITLE
Add check for minimum NDI & OBS version requirement - 6.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ DistroAV (Formerly OBS-NDI)
 - **NDI Filter** (a.k.a. **NDI Dedicated Output**) : Transmit a single OBS source or scene audio to NDI
 
 ## Requirements
-* OBS >= 30.0.0 (Qt6, x64/ARM64/AppleSilicon)
+* OBS >= 31.0.0 (Qt6, x64/ARM64/AppleSilicon)
 * [NDI Runtime >= 6](https://github.com/DistroAV/DistroAV/wiki/1.-Installation#required---ndi-runtime)  
 * [Remove old OBS-NDI plugin](https://github.com/DistroAV/DistroAV/wiki/OBS%E2%80%90NDI-Is-Now-DistroAV)
 

--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
     },
     "name": "distroav",
     "displayName": "DistroAV",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "website": "https://distroav.org",
     "author": "DistroAV",
     "email": "contact@distroav.org",

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -260,10 +260,9 @@ bool obs_module_load(void)
 			obs_get_version_string(), PLUGIN_MIN_OBS_VERSION);
 
 		auto title = "OBS version not supported";
-		auto message = "Error-424: Plugin requires OBS " +
-			       QTStr(PLUGIN_MIN_OBS_VERSION) + " or higher <br>";
+		auto message = "Error-424: Plugin requires OBS " + QTStr(PLUGIN_MIN_OBS_VERSION) + " or higher <br>";
 		showCriticalUnloadingMessageBoxDelayed(title, message);
-		
+
 		return false;
 	}
 	obs_log(LOG_DEBUG, "obs_module_load: Minimum OBS version met. Continuing...");
@@ -312,16 +311,18 @@ bool obs_module_load(void)
 	obs_log(LOG_INFO, "NDI Version detected: %s", QT_TO_UTF8(ndi_version_short));
 
 	if (!is_version_supported(QT_TO_UTF8(ndi_version_short), PLUGIN_MIN_NDI_VERSION)) {
-		obs_log(LOG_ERROR, "ERR-425 - %s requires at least NDI version %s. NDI Version detected: %s. Plugin will unload.",
+		obs_log(LOG_ERROR,
+			"ERR-425 - %s requires at least NDI version %s. NDI Version detected: %s. Plugin will unload.",
 			PLUGIN_DISPLAY_NAME, PLUGIN_MIN_NDI_VERSION, QT_TO_UTF8(ndi_version_short));
 		obs_log(LOG_DEBUG, "obs_module_load: NDI minimum version not met (%s). NDI version detected: %s.",
 			PLUGIN_MIN_NDI_VERSION, ndiLib->version());
-			
-			auto title = "NDI Library version not supported";
-			auto message = "Error-425: Plugin requires NDI " + QTStr(PLUGIN_MIN_NDI_VERSION) + " or higher <br> <br> Version detected: " +
-				       QT_TO_UTF8(ndi_version_short) + "<br> Get the latest NDI library at: <br>";
-			message += makeLink(PLUGIN_REDIRECT_NDI_REDIST_URL);
-			showCriticalUnloadingMessageBoxDelayed(title, message);
+
+		auto title = "NDI Library version not supported";
+		auto message = "Error-425: Plugin requires NDI " + QTStr(PLUGIN_MIN_NDI_VERSION) +
+			       " or higher <br> <br> Version detected: " + QT_TO_UTF8(ndi_version_short) +
+			       "<br> Get the latest NDI library at: <br>";
+		message += makeLink(PLUGIN_REDIRECT_NDI_REDIST_URL);
+		showCriticalUnloadingMessageBoxDelayed(title, message);
 		return false;
 	}
 

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -232,7 +232,6 @@ bool is_version_supported(const char *version, const char *min_version)
 
 bool obs_module_load(void)
 {
-
 	obs_log(LOG_INFO, "obs_module_load: you can haz %s (Version %s)", PLUGIN_DISPLAY_NAME, PLUGIN_VERSION);
 	// obs_log(LOG_DEBUG, "obs_module_load: Qt Version: %s (runtime), %s (compiled)", qVersion(), QT_VERSION_STR);
 
@@ -258,7 +257,7 @@ bool obs_module_load(void)
 			PLUGIN_MIN_OBS_VERSION);
 		obs_log(LOG_DEBUG,
 			"obs_module_load: OBS version detected is not compatible. OBS version detected: %s. OBS version required: %s",
-			PLUGIN_DISPLAY_NAME, obs_get_version_string(), PLUGIN_MIN_OBS_VERSION);
+			obs_get_version_string(), PLUGIN_MIN_OBS_VERSION);
 		return false;
 	}
 	obs_log(LOG_DEBUG, "obs_module_load: Minimum OBS version met. Continuing...");
@@ -310,7 +309,7 @@ bool obs_module_load(void)
 		obs_log(LOG_ERROR, "ERR-425 - %s requires at least NDI version %s. NDI Version detected: %s",
 			PLUGIN_DISPLAY_NAME, PLUGIN_MIN_NDI_VERSION, QT_TO_UTF8(ndi_version_short));
 		obs_log(LOG_DEBUG, "obs_module_load: NDI minimum version not met (%s). NDI version detected: %s.",
-			QT_TO_UTF8(ndi_version_short), PLUGIN_MIN_NDI_VERSION, ndiLib->version());
+			PLUGIN_MIN_NDI_VERSION, ndiLib->version());
 
 		obs_log(LOG_WARNING,
 			"Update the NDI SDK to at least %s. Plugin will continue to load but things will break.",

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -208,13 +208,37 @@ bool is_obsndi_installed()
 	return is_module_found("obs-ndi");
 }
 
+bool is_version_supported(const char *version, const char *min_version)
+{
+	if (version == nullptr || min_version == nullptr) {
+		return false;
+	}
+
+	auto version_parts = QString::fromUtf8(version).split(".");
+	auto min_version_parts = QString::fromUtf8(min_version).split(".");
+
+	for (int i = 0; i < qMax(version_parts.size(), min_version_parts.size()); ++i) {
+		auto version_part = i < version_parts.size() ? version_parts[i].toInt() : 0;
+		auto min_version_part = i < min_version_parts.size() ? min_version_parts[i].toInt() : 0;
+
+		if (version_part > min_version_part) {
+			return true;
+		} else if (version_part < min_version_part) {
+			return false;
+		}
+	}
+	return true;
+}
+
 bool obs_module_load(void)
 {
+
 	obs_log(LOG_INFO, "obs_module_load: you can haz %s (Version %s)", PLUGIN_DISPLAY_NAME, PLUGIN_VERSION);
 	// obs_log(LOG_DEBUG, "obs_module_load: Qt Version: %s (runtime), %s (compiled)", qVersion(), QT_VERSION_STR);
 
 	Config::Initialize();
 
+	// Check if the old version of the plugin is installed
 	if (is_obsndi_installed()) {
 		obs_log(LOG_ERROR, "ERR-403 - OBS-NDI is detected and needs to be uninstalled before %s can work.",
 			PLUGIN_DISPLAY_NAME);
@@ -226,6 +250,20 @@ bool obs_module_load(void)
 							       .arg(rehostUrl(PLUGIN_REDIRECT_UNINSTALL_OBSNDI_URL)));
 		return false;
 	}
+	obs_log(LOG_DEBUG, "obs_module_load: No OBS-NDI leftover detected. Continuing...");
+
+	// Check if this is using the minimum OBS version required by this plugin
+	if (!is_version_supported(obs_get_version_string(), PLUGIN_MIN_OBS_VERSION)) {
+		obs_log(LOG_ERROR, "ERR-424 - %s requires at least OBS version %s.", PLUGIN_DISPLAY_NAME,
+			PLUGIN_MIN_OBS_VERSION);
+		obs_log(LOG_DEBUG,
+			"obs_module_load: OBS version detected is not compatible. OBS version detected: %s. OBS version required: %s",
+			PLUGIN_DISPLAY_NAME, obs_get_version_string(), PLUGIN_MIN_OBS_VERSION);
+		return false;
+	}
+	obs_log(LOG_DEBUG, "obs_module_load: Minimum OBS version met. Continuing...");
+
+	// Check if the NDI SDK is installed & compatible
 
 	auto main_window = static_cast<QMainWindow *>(obs_frontend_get_main_window());
 
@@ -263,7 +301,24 @@ bool obs_module_load(void)
 		return false;
 	}
 
-	obs_log(LOG_INFO, "obs_module_load: NDI library initialized successfully ('%s')", ndiLib->version());
+	obs_log(LOG_INFO, "obs_module_load: NDI library detected ('%s')", ndiLib->version());
+
+	// Check if the minimum NDI Runtime/SDK required by this plugin is used
+	QString ndi_version_short = QRegularExpression(R"((\d+\.\d+\.\d+)$)").match(ndiLib->version()).captured(1);
+
+	if (!is_version_supported(QT_TO_UTF8(ndi_version_short), PLUGIN_MIN_NDI_VERSION)) {
+		obs_log(LOG_ERROR, "ERR-425 - %s requires at least NDI version %s. NDI Version detected: %s",
+			PLUGIN_DISPLAY_NAME, PLUGIN_MIN_NDI_VERSION, QT_TO_UTF8(ndi_version_short));
+		obs_log(LOG_DEBUG, "obs_module_load: NDI minimum version not met (%s). NDI version detected: %s.",
+			QT_TO_UTF8(ndi_version_short), PLUGIN_MIN_NDI_VERSION, ndiLib->version());
+
+		obs_log(LOG_WARNING,
+			"Update the NDI SDK to at least %s. Plugin will continue to load but things will break.",
+			PLUGIN_MIN_NDI_VERSION);
+		return false;
+	}
+
+	obs_log(LOG_INFO, "obs_module_load: NDI library initialized successfully");
 
 	ndi_source_info = create_ndi_source_info();
 	obs_register_source(&ndi_source_info);

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -307,7 +307,8 @@ bool obs_module_load(void)
 	obs_log(LOG_INFO, "obs_module_load: NDI library detected ('%s')", ndiLib->version());
 
 	// Check if the minimum NDI Runtime/SDK required by this plugin is used
-	QString ndi_version_short = QRegularExpression(R"((\d+\.\d+\.\d+\.\d+)$)").match(ndiLib->version()).captured(1);
+	QString ndi_version_short =
+		QRegularExpression(R"((\d+\.\d+(\.\d+)?(\.\d+)?$))").match(ndiLib->version()).captured(1);
 	obs_log(LOG_INFO, "NDI Version detected: %s", QT_TO_UTF8(ndi_version_short));
 
 	if (!is_version_supported(QT_TO_UTF8(ndi_version_short), PLUGIN_MIN_NDI_VERSION)) {

--- a/src/plugin-main.h
+++ b/src/plugin-main.h
@@ -26,7 +26,8 @@
 #include <Processing.NDI.Lib.h>
 
 #define PLUGIN_MIN_QT_VERSION "6.0.0"
-#define PLUGIN_MIN_OBS_VERSION "30.0.0"
+#define PLUGIN_MIN_OBS_VERSION "31.0.0"
+#define PLUGIN_MIN_NDI_VERSION "6.0.0"
 
 #define OBS_NDI_ALPHA_FILTER_ID "premultiplied_alpha_filter"
 


### PR DESCRIPTION
# Context
Prepare for 6.1 release
Add Minimum version check (OBS & NDI)

# Goal
Enforce minimum requirements in OBS Major version and NDI SDK
Unload plugin if minimum requirements are not met (avoid issues & breaking things)

# Why enforce min requirement for OBS/NDI version?
Read more at : https://github.com/DistroAV/DistroAV/discussions/1189

## TL;DR :

> Updated Minimum Requirement
> 
>     OBS v31+
>     NDI SDK/Runtime v6+
> 
> Why is this change necessary ?
> There are changes integrated in OBS 31 that split the configuration files and we are following the guidelines set by the OBS team for a sustainable OBS-user community.
> 
> NDI v6 has been widely available for months now and proven reliable. The codebase in DistroAV 6 already integrate with NDI v6, even tho we did not leverage new feature and code optimization (yet), this will be a possiblity at "anytime" with DistroAV 6.1.

Adding a note to this TL;DR above : some changes in the audio processing in the DistroAV code requires it and bugs relating to audio have been corrected in NDI 6.1 (still we are only enforcing 6.0 for now).

# Behavior expected
If the minimum OBS & NDI version are not met:
- The plugin will unload
- An error entry in the log will be displayed with a unique error code that can be easily searched for
- TODO : Add a more comprehensive solution in the wiki for the error code 424 & 425 (minimum version not met)
- TBC : An error popup will inform the user with the error code

If the minimum OBS & NDI versions are met:
- Happy days! It will load as expected.

# Change management / transparency / Roll-out plan
- Some users are still on 4.14, and have not yet moved to DistroAV v6, but have moved on to OBS 31 and NDI 6. So no more excuses to hold back upgrade. The 4.14 codebase is over a year old and 2 major versions behind and not maintained/supported.

- Some distros (Fedora?) are quite behind on NDI SDK (like 5.6), I have reached out to a couple maintainers of said package/distros (Nobara) that this might impact some of their users. - Fedora is not officially supported, so this was as far as I could go.

- OBS 31 config management changes means that once the plugin is used on that version onwards, there is no way back for the config. No backward compatibility / downgrading will be put in place (as more than 2/3 of the users are on OBS 31+ already)

- There are a lot of bug fixes and improvement in 6.1 that would have deserved a minor release. But here we are, the longer you wait to update, the more changes are required.

- It is expected that upgrade from DistroAV 6.0 to 6.1 to be seamless. It is expected the same from 4.14 to 6.1 (but not planned to be tested) 

