### PR TITLE
Create windows installer as part of github actions

### DIFF
--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -67,6 +67,22 @@ function Package {
     }
     Compress-Archive -Force @CompressArgs
     Log-Group
+
+    # Declare the location of the InnoSetup setup file
+    $IsccFile = "${ProjectRoot}/build_${Target}/installer-Windows.generated.iss"
+    if ( ! ( Test-Path -Path $IsccFile ) ) {
+        throw 'InnoSetup install script not found. Run the build script or the CMake build and install procedures first.'
+    }
+
+    Log-Information 'Creating InnoSetup installer...'
+    Push-Location -Stack BuildTemp
+    Ensure-Location -Path "${ProjectRoot}/release"
+    Copy-Item -Path ${Configuration} -Destination Package -Recurse
+    Invoke-External iscc ${IsccFile} /O"${ProjectRoot}/release" /F"${OutputName}-Installer"
+    Remove-Item -Path Package -Recurse
+    Pop-Location -Stack BuildTemp
+
+    Log-Group
 }
 
 Package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(
     src/preview-output.cpp
     src/preview-output.h
 )
-configure_file(cmake/windows/resources/installer-Windows.iss.in "${CMAKE_CURRENT_BINARY_DIR}/installer-Windows.generated.iss")
+configure_file(cmake/windows/resources/installer-Windows.iss.in 
+  "${CMAKE_CURRENT_BINARY_DIR}/installer-Windows.generated.iss")
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/lib/ndi)
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,6 @@ target_sources(
     src/preview-output.cpp
     src/preview-output.h
 )
-
+configure_file(cmake/windows/resources/installer-Windows.iss.in "${CMAKE_CURRENT_BINARY_DIR}/installer-Windows.generated.iss")
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/lib/ndi)
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})


### PR DESCRIPTION
To build the windows installer as part of the github actions, we need to generate the .iss config file and invoke the iscc installer builder with that file in the Package-Windows.ps1 file. These steps are not part of the plugin-template, so were added using the instructions provided here: https://github.com/obsproject/obs-plugintemplate/wiki/Create-an-InnoSetup-Installer