### PR TITLE
Check for sender not equal nullptr when creating output

### DIFF
--- a/src/ndi-output.cpp
+++ b/src/ndi-output.cpp
@@ -220,7 +220,7 @@ bool ndi_output_start(void *data)
 	send_desc.clock_audio = false;
 
 	o->ndi_sender = ndiLib->send_create(&send_desc);
-	if (o->ndi_sender) {
+	if (o->ndi_sender != nullptr) {
 		o->started = obs_output_begin_data_capture(o->output, flags);
 		if (o->started) {
 			obs_log(LOG_DEBUG, "'%s' ndi_output_start: ndi output started", name);


### PR DESCRIPTION
This addresses issue reported in https://github.com/DistroAV/DistroAV/issues/1326 where the format is reported as not supported. In actuality, the test for if the sender is created is not done properly and depending on the value of the ndi_sender, it can fail the if (o->ndi_sender) test, even when the valid sender is created.

As pointed out in the issue, the NDI documentation says this is a valid way to test (treating as a boolean), but is not adequate and need to be changed to suggest nullptr test instead.

