### PR TITLE
Add random number to NDI test output name

### DIFF
--- a/src/main-output.cpp
+++ b/src/main-output.cpp
@@ -18,6 +18,7 @@
 #include "main-output.h"
 
 #include "plugin-main.h"
+#include <random>
 
 struct main_output {
 	bool is_running;
@@ -109,7 +110,17 @@ bool main_output_is_supported()
 	auto output_groups = config->OutputGroups;
 
 	obs_data_t *output_settings = obs_data_create();
-	obs_data_set_string(output_settings, "ndi_name", "NDI Output Support Test");
+
+	// Append a random number to the test NDI name to avoid
+	// conflicts with existing outputs
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::uniform_int_distribution<> dis(10000, 99999);
+
+	int randomNum = dis(gen);
+	std::string testString = "NDI Output Support Test " + std::to_string(randomNum);
+
+	obs_data_set_string(output_settings, "ndi_name", testString.c_str());
 	obs_data_set_string(output_settings, "ndi_groups", "DistroAV Config");
 
 	bool is_supported = true;
@@ -172,8 +183,6 @@ void main_output_init()
 	auto is_enabled = config->OutputEnabled;
 
 	if (is_enabled && !main_output_is_supported()) {
-		config->OutputEnabled = false;
-		config->Save();
 		is_enabled = false;
 		obs_log(LOG_WARNING, "WARN-426 - NDI Main Output disabled, format not supported");
 	}


### PR DESCRIPTION
When starting multiple OBS Studio instances at the same time, the creation of an NDI sender can fail if there is already a sender with the same name created. This PR adds a 5 digit random number to the name "NDI Output Support Test", so that every name is unique.

This is to address issue https://github.com/DistroAV/DistroAV/issues/1326 where the Main Output is disabled. This was because of "invalid format", but in reality the sender was not able to be created as the name already was being used by another instance of OBS. 

I tested this change in the same scenario as the one in issue 1326: 4 portable instances launched at the same time in Task Scheduler. I confirmed all main outputs were started and log files were clean or Errors and Warnings.

Also in this PR is NOT turning off the Main Output in the config saved for the user. This does not change the behavior for the original case where a user has chosen an unsupported output format. 

This was tested by:
1. Toggling off the main output, changing the pixel format, and then not being able to turn on main output.
2. With main output turned on, loaded a profile with an invalid pixel format and it did not crash. When bringing up the output dialog, the main output was still turned on, but the container was not enabled and not outputting main. 
3. When choosing a profile with a supported pixel format, the main output restarted as it was still turned on.