### PR TITLE
Fix NDI frame resize mid stream from Teams

### DIFF
--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -1230,18 +1230,6 @@ void ndi_source_destroy(void *data)
 	obs_log(LOG_DEBUG, "'%s' -ndi_source_destroy(…)", obs_source_name);
 }
 
-uint32_t ndi_source_get_width(void *data)
-{
-	auto s = (ndi_source_t *)data;
-	return s->width;
-}
-
-uint32_t ndi_source_get_height(void *data)
-{
-	auto s = (ndi_source_t *)data;
-	return s->height;
-}
-
 obs_source_info create_ndi_source_info()
 {
 	// https://docs.obsproject.com/reference-sources#source-definition-structure-obs-source-info
@@ -1262,9 +1250,6 @@ obs_source_info create_ndi_source_info()
 	ndi_source_info.hide = ndi_source_hidden;
 	ndi_source_info.deactivate = ndi_source_deactivated;
 	ndi_source_info.destroy = ndi_source_destroy;
-
-	ndi_source_info.get_width = ndi_source_get_width;
-	ndi_source_info.get_height = ndi_source_get_height;
 
 	return ndi_source_info;
 }


### PR DESCRIPTION
This PR is to fix https://github.com/DistroAV/DistroAV/issues/1463 [Bug]: NDI Source changes scaling randomly when using NDI from Teams. 

There appears to have been recent changes to how Teams sends NDI sources, mainly an altering of the width and height mid stream for various reasons.

To fix the scaling issue, the user must set the Transform of the NDI source to Fit to Screen (Ctrl-F), or Edit the Transform (Ctrl-E) and set Bounds to "Cover". 

This will keep the scaling of the image the same in OBS as the Teams NDI source changes. However, there is flashing of the image in OBS where it sometimes momentarily shows a smaller version in the Preview/Program windows. 

A solution to the flashing problem was suggested in [the issue](https://github.com/DistroAV/DistroAV/issues/1463). Because we are sending async frames, the frame size returned by get_width and get_height will be ahead of what is about to be rendered. The suggested solution is to remove these callbacks from the ndi_source_info so the async sizes will be used instead.

To test this change, I created a test NDI source which alters the frame size between 1600 and 800 wide, every second.
I was able to duplicate the scaling issue. After applying the proper Transform to the source the scaling issue went away, but the flashing persisted. After removing the get_width and get_height callbacks, the flashing went away. I also tested by creating new NDI sources and using old NDI sources and everything worked fine. Also confirmed the empty frame behavior still works when receiving NDI output from OBS.  