### PR TITLE
Potential fix for code scanning alert no. 12: Multiplication result converted to larger type

### DIFF
--- a/src/ndi-output.cpp
+++ b/src/ndi-output.cpp
@@ -433,7 +433,7 @@ void ndi_output_rawaudio(void *data, audio_data *frame)
 	audio_frame.channel_stride_in_bytes = frame->frames * 4;
 	audio_frame.FourCC = NDIlib_FourCC_audio_type_FLTP;
 
-	const size_t data_size = audio_frame.no_channels * audio_frame.channel_stride_in_bytes;
+	const size_t data_size = (size_t)audio_frame.no_channels * (size_t)audio_frame.channel_stride_in_bytes;
 
 	if (data_size > o->audio_conv_buffer_size) {
 		obs_log(LOG_DEBUG, "ndi_output_rawaudio('%s'): growing audio_conv_buffer from %zu to %zu bytes",


### PR DESCRIPTION
Potential fix for [https://github.com/DistroAV/DistroAV/security/code-scanning/12](https://github.com/DistroAV/DistroAV/security/code-scanning/12)

General fix: ensure at least one operand is cast to the larger destination type **before** multiplication so the arithmetic executes in that larger type.

Best fix here (minimal and behavior-preserving): in `src/ndi-output.cpp` at the `data_size` computation, cast `audio_frame.no_channels` (or `audio_frame.channel_stride_in_bytes`) to `size_t` before multiplying.

Change:
- From:
  - `const size_t data_size = audio_frame.no_channels * audio_frame.channel_stride_in_bytes;`
- To:
  - `const size_t data_size = (size_t)audio_frame.no_channels * (size_t)audio_frame.channel_stride_in_bytes;`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
