### PR TITLE
Simplify check for supported pixel format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ target_sources(
     src/ndi-finder.h
     src/ndi-finder.cpp
     src/ndi-output.cpp
+    src/test-output.cpp
     src/ndi-source.cpp
     src/plugin-main.cpp
     src/plugin-main.h

--- a/src/main-output.cpp
+++ b/src/main-output.cpp
@@ -102,33 +102,13 @@ void main_output_start()
 bool main_output_is_supported()
 {
 	obs_log(LOG_DEBUG, "+main_output_is_supported()");
-	auto config = Config::Current();
-	auto output_name = config->OutputName;
-	auto output_groups = config->OutputGroups;
-
 	obs_data_t *output_settings = obs_data_create();
-
-	// Append a random number to the test NDI name to avoid
-	// conflicts with existing outputs
-	std::random_device rd;
-	std::mt19937 gen(rd());
-	std::uniform_int_distribution<> dis(10000, 99999);
-
-	QString output_support_test_name = "NDI Output Support Test " + QString::number(dis(gen));
-
-	obs_data_set_string(output_settings, "ndi_name", QT_TO_UTF8(output_support_test_name));
-	obs_data_set_string(output_settings, "ndi_groups", "DistroAV Config");
-
+	auto output = obs_output_create("test_ndi_output", "Test NDI Output", output_settings, nullptr);
 	bool is_supported = false;
 	context.last_error = QString("");
 
-	auto output = obs_output_create("ndi_output", "NDI Main Output", output_settings, nullptr);
-	obs_data_release(output_settings);
-
 	if (output != nullptr) {
-		obs_output_start(output);
-
-		if (!obs_output_active(output)) {
+		if (!obs_output_start(output)) {
 			is_supported = false;
 			context.last_error = obs_output_get_last_error(output);
 			obs_log(LOG_DEBUG, "main_output_is_supported: '%s'", QT_TO_UTF8(context.last_error));

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -56,6 +56,9 @@ struct obs_source_info ndi_source_info;
 extern struct obs_output_info create_ndi_output_info();
 struct obs_output_info ndi_output_info;
 
+extern struct obs_output_info create_test_output_info();
+struct obs_output_info test_output_info;
+
 extern struct obs_source_info create_ndi_filter_info();
 struct obs_source_info ndi_filter_info;
 
@@ -262,6 +265,9 @@ static void register_plugin_features()
 
 	ndi_output_info = create_ndi_output_info();
 	obs_register_output(&ndi_output_info);
+
+	test_output_info = create_test_output_info();
+	obs_register_output(&test_output_info);
 
 	ndi_filter_info = create_ndi_filter_info();
 	obs_register_source(&ndi_filter_info);

--- a/src/test-output.cpp
+++ b/src/test-output.cpp
@@ -1,0 +1,93 @@
+/******************************************************************************
+	Copyright (C) 2016-2024 DistroAV <contact@distroav.org>
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, see <https://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "plugin-main.h"
+
+typedef struct {
+	obs_output_t *output;
+} test_output_t;
+
+const char *test_output_getname(void *)
+{
+	return "Test NDI Output";
+}
+
+void *test_output_create(obs_data_t *settings, obs_output_t *output)
+{
+	auto o = (test_output_t *)bzalloc(sizeof(test_output_t));
+	o->output = output;
+	return o;
+}
+
+static const std::map<video_format, std::string> test_video_to_color_format_map = {{VIDEO_FORMAT_P010, "P010"},
+										   {VIDEO_FORMAT_I010, "I010"},
+										   {VIDEO_FORMAT_P216, "P216"},
+										   {VIDEO_FORMAT_P416, "P416"}};
+
+bool test_output_start(void *data)
+{
+	auto o = (test_output_t *)data;
+
+	video_t *video = obs_output_video(o->output);
+	obs_output_set_last_error(o->output, "");
+
+	if (video) {
+		video_format format = video_output_get_format(video);
+
+		switch (format) {
+		case VIDEO_FORMAT_I444:
+		case VIDEO_FORMAT_NV12:
+		case VIDEO_FORMAT_I420:
+		case VIDEO_FORMAT_RGBA:
+		case VIDEO_FORMAT_BGRA:
+		case VIDEO_FORMAT_BGRX:
+			break;
+
+		default:
+			obs_log(LOG_ERROR, "ERR-410 - NDI Output cannot start : Unsupported pixel format %d.", format);
+			auto error_string = obs_module_text("NDIPlugin.OutputSettings.LastError") +
+					    test_video_to_color_format_map.at(format);
+			obs_output_set_last_error(o->output, error_string.c_str());
+			return false;
+		}
+	}
+	return true;
+}
+
+void test_output_stop(void *data, uint64_t) {}
+
+void test_output_destroy(void *data)
+{
+	auto o = (test_output_t *)data;
+	bfree(o);
+}
+
+void test_output_rawvideo(void *data, video_data *frame) {}
+
+obs_output_info create_test_output_info()
+{
+	obs_output_info test_output_info = {};
+	test_output_info.id = "test_ndi_output";
+	test_output_info.flags = OBS_OUTPUT_VIDEO;
+	test_output_info.create = test_output_create;
+	test_output_info.start = test_output_start;
+	test_output_info.get_name = test_output_getname;
+	test_output_info.stop = test_output_stop;
+	test_output_info.destroy = test_output_destroy;
+	test_output_info.raw_video = test_output_rawvideo;
+	return test_output_info;
+}

--- a/src/test-output.cpp
+++ b/src/test-output.cpp
@@ -26,7 +26,7 @@ const char *test_output_getname(void *)
 	return "Test NDI Output";
 }
 
-void *test_output_create(obs_data_t *settings, obs_output_t *output)
+void *test_output_create(obs_data_t *, obs_output_t *output)
 {
 	auto o = (test_output_t *)bzalloc(sizeof(test_output_t));
 	o->output = output;
@@ -68,7 +68,7 @@ bool test_output_start(void *data)
 	return true;
 }
 
-void test_output_stop(void *data, uint64_t) {}
+void test_output_stop(void *, uint64_t) {}
 
 void test_output_destroy(void *data)
 {
@@ -76,7 +76,7 @@ void test_output_destroy(void *data)
 	bfree(o);
 }
 
-void test_output_rawvideo(void *data, video_data *frame) {}
+void test_output_rawvideo(void *, video_data *) {}
 
 obs_output_info create_test_output_info()
 {


### PR DESCRIPTION
This PR simplifies the test for pixel format supported. The old test created a full NDI Main Output, including a NDI sender just to check if the current pixel format (OBS->Settings->Advanced) is supported by NDI. This created the following lines in the logs file without verbose or debug turned on:

```
14:02:58.238: [distroav] NDI Output Updated. 'NDI Output Support Test 49585'
14:02:58.241: [distroav] NDI Output started successfully. 'NDI Output Support Test 49585'
14:02:58.241: Output 'NDI Main Output': stopping
14:02:58.241: Output 'NDI Main Output': Total frames output: 0
14:02:58.241: Output 'NDI Main Output': Total drawn frames: 0
14:02:58.242: [distroav] NDI Output Stopped. 'NDI Output Support Test 49585'
```

These messages can be misleading, as it appears that the NDI Main Output is stopping. Actually, only the Support Test output was stopped.

To simplify, a new output is registered with OBS, called "test_ndi_output". This output will only test if the video format supported in the test_output_start callback. The main_output_is_supported() method was modified to use this new test_ndi_output instead of creating a Main Output. 

Simplifying this also makes it easier to fix issues related to web-sockets changing output settings.

Tested by turning off output, selecting invalid pixel format in Settings->Advanced, bringing up the DistroAV NDI Settings dialog and witnessing the error code and that the UX is the same as before. Also tested by loading profile with a bad pixel format, and a good pixel format and witnessed the output starting and stopping and the Output Settings UI reflecting the current state.