### PR TITLE
Source: Fix alpha transparency in Low/Lowest

### DIFF
--- a/src/ndi-source.cpp
+++ b/src/ndi-source.cpp
@@ -462,10 +462,12 @@ void *ndi_source_thread(void *data)
 			//
 			// Update recv_desc.latency
 			//
-			if (s->config.latency == PROP_LATENCY_NORMAL)
-				recv_desc.color_format = NDIlib_recv_color_format_UYVY_BGRA;
-			else
-				recv_desc.color_format = NDIlib_recv_color_format_fastest;
+			// "fastest" decodes alpha-carrying sources to UYVA,
+			// whose separate alpha plane is then dropped when
+			// mapped to VIDEO_FORMAT_UYVY in process_video2().
+			// Use UYVY_BGRA for all latency modes: non-alpha
+			// sources still decode to UYVY (zero-copy). #937
+			recv_desc.color_format = NDIlib_recv_color_format_UYVY_BGRA;
 			obs_log(LOG_DEBUG,
 				"'%s' ndi_source_thread: reset_ndi_receiver; Setting recv_desc.color_format=%d",
 				obs_source_name, //


### PR DESCRIPTION
> **Disclosure:** this fix was diagnosed, implemented and tested with the help of an AI coding agent (LLM). All results were reproduced and reviewed by a human before submission.

Fixes #937.

**Problem:** NDI sources carrying alpha (ProPresenter, FreeShow, vTube Studio, …) lose transparency when the source latency mode is Low or Lowest.

**Root cause:** with `NDIlib_recv_color_format_fastest`, the NDI runtime decodes alpha-carrying streams to **UYVA** (UYVY + separate alpha plane). `ndi_source_thread_process_video2()` maps UYVA → `VIDEO_FORMAT_UYVY`, silently discarding the alpha plane. Verified with a local probe receiver against a BGRA test source: `UYVY_BGRA` → BGRA with alpha intact; `fastest` → UYVA.

**Fix:** request `NDIlib_recv_color_format_UYVY_BGRA` for all latency modes. Non-alpha sources still decode zero-copy to UYVY (same as `fastest`); alpha sources are converted to BGRA by the NDI runtime.

**Notes:**
- #954 previously fixed this for Low, but it only ever landed on `develop` and was lost in the 6.0.0 rewrite — no shipped release contains it. This PR extends the same approach to Lowest as well.
- The "proper" fix (native UYVA support, #1261) requires `VIDEO_FORMAT_UYVA` in libobs (obsproject/obs-studio#10345, closed unmerged). This is a minimal alternative that works with stock OBS today.
- Could a maintainer please add the `Seeking Testers` label so CI packages test installers?

**Testing:** built for macOS (6.2.1) and Windows x64 (this branch); verified alpha checkerboard and real ProPresenter/FreeShow feeds render with transparency in **Normal, Low, and Lowest**. Plugin loads cleanly; no new warnings.
