### PR TITLE
Output: sync WebSocket settings with UI

### DIFF
--- a/src/main-output.cpp
+++ b/src/main-output.cpp
@@ -35,6 +35,24 @@ QString main_output_last_error()
 	return context.last_error;
 };
 
+bool main_output_sync_settings(obs_output_t *output, obs_data_t *settings)
+{
+	if (output != context.output)
+		return false;
+
+	context.ndi_name = obs_data_get_string(settings, "ndi_name");
+	context.ndi_groups = obs_data_get_string(settings, "ndi_groups");
+
+	auto config = Config::Current(false);
+	if (config->OutputName == context.ndi_name && config->OutputGroups == context.ndi_groups)
+		return true;
+
+	config->OutputName = context.ndi_name;
+	config->OutputGroups = context.ndi_groups;
+	config->Save();
+	return true;
+}
+
 void on_main_output_started(void *, calldata_t *)
 {
 	obs_log(LOG_DEBUG, "+on_main_output_started()");

--- a/src/main-output.h
+++ b/src/main-output.h
@@ -17,7 +17,9 @@
 
 #pragma once
 #include <QString>
+#include <obs.h>
 void main_output_deinit();
 void main_output_init();
 QString main_output_last_error();
 bool main_output_is_supported();
+bool main_output_sync_settings(obs_output_t *output, obs_data_t *settings);

--- a/src/ndi-output.cpp
+++ b/src/ndi-output.cpp
@@ -16,6 +16,8 @@
 ******************************************************************************/
 
 #include "plugin-main.h"
+#include "main-output.h"
+#include "preview-output.h"
 #include "sync-debug.h"
 #include <util/threading.h>
 #include <chrono>
@@ -265,6 +267,9 @@ void ndi_output_update(void *data, obs_data_t *settings)
 	o->ndi_groups = groups;
 	o->uses_video = obs_data_get_bool(settings, "uses_video");
 	o->uses_audio = obs_data_get_bool(settings, "uses_audio");
+
+	if (!main_output_sync_settings(o->output, settings))
+		preview_output_sync_settings(o->output, settings);
 
 	obs_log(LOG_INFO, "NDI Output Updated. '%s'", name);
 	obs_log(LOG_DEBUG, "ndi_output_update(name='%s', groups='%s', uses_video='%s', uses_audio='%s')", name, groups,

--- a/src/preview-output.cpp
+++ b/src/preview-output.cpp
@@ -41,6 +41,24 @@ struct preview_output {
 
 static struct preview_output context = {0};
 
+bool preview_output_sync_settings(obs_output_t *output, obs_data_t *settings)
+{
+	if (output != context.output)
+		return false;
+
+	context.ndi_name = obs_data_get_string(settings, "ndi_name");
+	context.ndi_groups = obs_data_get_string(settings, "ndi_groups");
+
+	auto config = Config::Current(false);
+	if (config->PreviewOutputName == context.ndi_name && config->PreviewOutputGroups == context.ndi_groups)
+		return true;
+
+	config->PreviewOutputName = context.ndi_name;
+	config->PreviewOutputGroups = context.ndi_groups;
+	config->Save();
+	return true;
+}
+
 void on_preview_scene_changed(enum obs_frontend_event event, void *param);
 void render_preview_source(void *param, uint32_t cx, uint32_t cy);
 

--- a/src/preview-output.h
+++ b/src/preview-output.h
@@ -17,5 +17,8 @@
 
 #pragma once
 
+#include <obs.h>
+
 void preview_output_deinit();
 void preview_output_init();
+bool preview_output_sync_settings(obs_output_t *output, obs_data_t *settings);


### PR DESCRIPTION
`SetOutputSettings` updated the live `ndi_output` instance, while the DistroAV output dialog continued to load its name and groups from the plugin configuration. As a result, a WebSocket change succeeded but the dialog displayed the previous values.

This change identifies updates for DistroAV's managed main and preview outputs, mirrors their `ndi_name` and `ndi_groups` into the corresponding plugin configuration, and persists changes only when values differ. Dedicated NDI outputs are unaffected.

Closes #1438.

Validation:
- `git diff --check`
- upstream CI build and formatting matrix requested by this PR
- local upstream macOS build could not run because the available command-line environment does not include the full Xcode generator
